### PR TITLE
Provide default root static directory

### DIFF
--- a/tom_setup/management/commands/tom_setup.py
+++ b/tom_setup/management/commands/tom_setup.py
@@ -60,6 +60,10 @@ class Command(BaseCommand):
             os.mkdir(os.path.join(BASE_DIR, 'templates'))
         except FileExistsError:
             pass
+        try:
+            os.mkdir(os.path.join(BASE_DIR, 'static'))
+        except FileExistsError:
+            pass
         self.ok()
 
     def run_migrations(self):

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -142,6 +142,7 @@ DATE_FORMAT = 'Y-m-d'
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, '_static')
+STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
 MEDIA_ROOT = os.path.join(BASE_DIR, 'data')
 MEDIA_URL = '/data/'
 


### PR DESCRIPTION
This commit makes sure that the setup script creates a top level
`static` directory and adds the appropriate `STATICFILES_DIRS` setting
so that users can place static files here immediately without needing to
start an app (as suggested in the django docs). This commit will be
accompanied by the appropriate documentation updates.

Fixes https://github.com/TOMToolkit/tom_base/issues/42