### PR TITLE
Add support for external code hooks

### DIFF
--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -167,6 +167,11 @@ FACILITIES = {
     }
 }
 
+HOOKS = {
+    'target_post_save': 'tom_common.hooks.target_post_save',
+    'observation_change_state': 'tom_common.hooks.observation_change_state'
+}
+
 try:
     from local_settings import * # noqa
 except ImportError:

--- a/tom_common/hooks.py
+++ b/tom_common/hooks.py
@@ -1,0 +1,30 @@
+from django.conf import settings
+from importlib import import_module
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def import_method(name):
+    mod_name, method = name.rsplit('.', 1)
+    try:
+        mod = import_module(mod_name)
+        m = getattr(mod, method)
+    except (ImportError, AttributeError):
+        raise ImportError('Could not import {}. Did you provide the correct path?'.format(name))
+    return m
+
+
+def run_hook(name, *args, **kwargs):
+    hook = settings.HOOKS.get(name)
+    if hook:
+        method = import_method(hook)
+        return method(*args, **kwargs)
+
+
+def target_post_save(target, created):
+    logger.info('Target post save hook: {} created: {}'.format(target, created))
+
+
+def observation_change_state(observation, previous_state):
+    logger.info('Observation change state hook: {} from {} to {}'.format(observation, previous_state))

--- a/tom_common/hooks.py
+++ b/tom_common/hooks.py
@@ -23,8 +23,8 @@ def run_hook(name, *args, **kwargs):
 
 
 def target_post_save(target, created):
-    logger.info('Target post save hook: {} created: {}'.format(target, created))
+    logger.info('Target post save hook: %s created: %s', target, created)
 
 
 def observation_change_state(observation, previous_state):
-    logger.info('Observation change state hook: {} from {} to {}'.format(observation, previous_state))
+    logger.info('Observation change state hook: %s from %s to %s', observation, previous_state, observation.status)

--- a/tom_observations/admin.py
+++ b/tom_observations/admin.py
@@ -1,3 +1,7 @@
 from django.contrib import admin
 
+from tom_observations.models import ObservationRecord
+
+admin.site.register(ObservationRecord)
+
 # Register your models here.

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -172,6 +172,11 @@ FACILITIES = {
     }
 }
 
+HOOKS = {
+    'target_post_save': 'tom_common.hooks.target_post_save',
+    'observation_change_state': 'tom_common.hooks.observation_change_state'
+}
+
 try:
     from local_settings import * # noqa
 except ImportError:

--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -80,7 +80,7 @@ class Target(models.Model):
         run_hook('target_post_save', target=self, created=created)
 
     def __str__(self):
-        return self.identifier
+        return str(self.identifier)
 
     def get_absolute_url(self):
         return reverse('targets:detail', kwargs={'pk': self.id})

--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone, timedelta
 
 from tom_observations import facility
 from tom_observations.utils import get_rise_set, get_last_rise_set_pair
+from tom_common.hooks import run_hook
 
 
 GLOBAL_TARGET_FIELDS = ['identifier', 'name', 'type']
@@ -72,6 +73,11 @@ class Target(models.Model):
 
     class Meta:
         ordering = ('id',)
+
+    def save(self, *args, **kwargs):
+        created = False if self.id else True
+        super().save(*args, **kwargs)
+        run_hook('target_post_save', target=self, created=created)
 
     def __str__(self):
         return self.identifier


### PR DESCRIPTION
Adds support for providing arbitrary code hooks to certain actions
within the TOM toolkit. The goal of this is to make it easy for TOM
authors to run custom scripts without needing to change the TOM
internals.

Documentation: https://tomtoolkit.github.io/docs/custom_code

Fixes https://github.com/TOMToolkit/tom_base/issues/46