### PR TITLE
Handle external auth problems

### DIFF
--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -61,6 +61,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'tom_common.middleware.ExternalServiceMiddleware',
 ]
 
 ROOT_URLCONF = 'tom_common.urls'

--- a/tom_common/exceptions.py
+++ b/tom_common/exceptions.py
@@ -1,0 +1,2 @@
+class ImproperCredentialsException(Exception):
+    pass

--- a/tom_common/middleware.py
+++ b/tom_common/middleware.py
@@ -1,0 +1,22 @@
+from tom_common.exceptions import ImproperCredentialsException
+from django.urls import reverse
+from django.shortcuts import redirect
+from django.contrib import messages
+
+
+class ExternalServiceMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_exception(self, request, exception):
+        if isinstance(exception, ImproperCredentialsException):
+            msg = 'There was a problem authenticating with {}. Please check you have the correct credentials.'.format(
+                str(exception)
+            )
+            messages.error(request, msg)
+            return redirect(reverse('home'))
+        raise exception

--- a/tom_observations/views.py
+++ b/tom_observations/views.py
@@ -13,6 +13,7 @@ from django.contrib import messages
 
 from .models import ObservationRecord, DataProduct, DataProductGroup
 from .forms import ManualObservationForm, AddProductToGroupForm, DataProductUploadForm
+from tom_common.exceptions import ImproperCredentialsException
 from tom_targets.models import Target
 
 

--- a/tom_observations/views.py
+++ b/tom_observations/views.py
@@ -13,7 +13,6 @@ from django.contrib import messages
 
 from .models import ObservationRecord, DataProduct, DataProductGroup
 from .forms import ManualObservationForm, AddProductToGroupForm, DataProductUploadForm
-from tom_common.exceptions import ImproperCredentialsException
 from tom_targets.models import Target
 
 

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -62,6 +62,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'tom_common.middleware.ExternalServiceMiddleware',
 ]
 
 ROOT_URLCONF = 'tom_common.urls'


### PR DESCRIPTION
This commit adds a middleware which catches a custom exception
`ImproperCredentialsException` which should be raised by modules when
there is an authentication problem. If left uncaught, this exception
will be handled by the custom middleware which will redirect the user to
the homepage and display an error.

Fixes https://github.com/TOMToolkit/tom_base/issues/38