### PR TITLE
Feature/mars target extras

### DIFF
--- a/tom_alerts/brokers/mars.py
+++ b/tom_alerts/brokers/mars.py
@@ -6,7 +6,7 @@ from django import forms
 from crispy_forms.layout import Layout, Div, Fieldset, HTML
 
 from tom_alerts.alerts import GenericQueryForm
-from tom_targets.models import Target
+from tom_targets.models import Target, TargetExtra
 
 MARS_URL = 'https://mars.lco.global'
 
@@ -158,15 +158,22 @@ class MARSBroker(object):
 
     @classmethod
     def to_target(clazz, alert):
-        return Target(
-            identifier=alert['lco_id'],
-            name=alert['objectId'],
+        alert_copy = alert.copy()
+        target = Target(
+            identifier=alert_copy['lco_id'],
+            name=alert_copy['objectId'],
             type='SIDEREAL',
-            ra=alert['candidate']['ra'],
-            dec=alert['candidate']['dec'],
-            galactic_lng=alert['candidate']['l'],
-            galactic_lat=alert['candidate']['b'],
+            ra=alert_copy['candidate'].pop('ra'),
+            dec=alert_copy['candidate'].pop('dec'),
+            galactic_lng=alert_copy['candidate'].pop('l'),
+            galactic_lat=alert_copy['candidate'].pop('b'),
         )
+        target_extras = []
+        for k, v in alert_copy['candidate'].items():
+            if v is not None:
+                target_extras.append(TargetExtra(key=k, value=v))
+
+        return target, target_extras
 
     @classmethod
     def to_generic_alert(clazz, alert):

--- a/tom_alerts/brokers/mars.py
+++ b/tom_alerts/brokers/mars.py
@@ -159,7 +159,7 @@ class MARSBroker(object):
     @classmethod
     def to_target(clazz, alert):
         alert_copy = alert.copy()
-        target = Target(
+        target = Target.objects.create(
             identifier=alert_copy['lco_id'],
             name=alert_copy['objectId'],
             type='SIDEREAL',
@@ -168,12 +168,11 @@ class MARSBroker(object):
             galactic_lng=alert_copy['candidate'].pop('l'),
             galactic_lat=alert_copy['candidate'].pop('b'),
         )
-        target_extras = []
         for k, v in alert_copy['candidate'].items():
             if v is not None:
-                target_extras.append(TargetExtra(key=k, value=v))
+                TargetExtra.objects.create(target=target, key=k, value=v)
 
-        return target, target_extras
+        return target
 
     @classmethod
     def to_generic_alert(clazz, alert):

--- a/tom_alerts/templates/tom_alerts/query_result.html
+++ b/tom_alerts/templates/tom_alerts/query_result.html
@@ -4,13 +4,13 @@
 <h2>Query Result for {{ query }}</h2>
 <table class="table table-striped">
   <thead>
-    <tr><th>Time</th><th>Name</th><th>RA</th><th>Dec</th><th>Mag</th><th>Score</th><th>View</th><th>Create Target</th></tr>
+    <tr><th>Time</th><th>Id</th><th>RA</th><th>Dec</th><th>Mag</th><th>Score</th><th>View</th><th>Create Target</th></tr>
   </thead>
   <tbody>
     {% for alert in alerts %}
     <tr>
       <td>{{ alert.timestamp }}</td>
-      <td>{{ alert.name }}</td>
+      <td>{{ alert.id }}</td>
       <td>{{ alert.ra|floatformat:3 }}</td>
       <td>{{ alert.dec|floatformat:3 }}</td>
       <td>{{ alert.mag|floatformat:3 }}</td>

--- a/tom_alerts/tests.py
+++ b/tom_alerts/tests.py
@@ -162,7 +162,6 @@ class TestBrokerViews(TestCase):
             parameters='{"name": "Hoth"}',
         )
         response = self.client.get(reverse('tom_alerts:run', kwargs={'pk': broker_query.id}))
-        self.assertContains(response, 'Hoth')
         self.assertContains(response,  '66')
 
     def test_update_query(self):

--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -111,6 +111,10 @@ class CreateTargetFromAlertView(LoginRequiredMixin, View):
         alert_id = self.request.POST['alert_id']
         broker_class = get_service_class(broker_name)
         alert = broker_class.fetch_alert(alert_id)
-        target = broker_class.to_target(alert)
+        target, target_extras = broker_class.to_target(alert)
         target.save()
+        for target_extra in target_extras:
+            target_extra.target = target
+            target_extra.save()
+
         return redirect(reverse('tom_targets:detail', kwargs={'pk': target.id}))

--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -111,10 +111,7 @@ class CreateTargetFromAlertView(LoginRequiredMixin, View):
         alert_id = self.request.POST['alert_id']
         broker_class = get_service_class(broker_name)
         alert = broker_class.fetch_alert(alert_id)
-        target, target_extras = broker_class.to_target(alert)
+        target = broker_class.to_target(alert)
         target.save()
-        for target_extra in target_extras:
-            target_extra.target = target
-            target_extra.save()
 
         return redirect(reverse('tom_targets:detail', kwargs={'pk': target.id}))

--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -113,5 +113,4 @@ class CreateTargetFromAlertView(LoginRequiredMixin, View):
         alert = broker_class.fetch_alert(alert_id)
         target = broker_class.to_target(alert)
         target.save()
-
         return redirect(reverse('tom_targets:detail', kwargs={'pk': target.id}))


### PR DESCRIPTION
When creating a target from a MARS alert, save all the non null
parameters as key value pairs on the created target as to preserve as
much information from the original alert as possible.

Also switch the alert listing to use the alert id rather than name for
consistency.

Fixes: #24
Fixes: #23