### PR TITLE
 Add support for sexigesimal 

### DIFF
--- a/tom_common/templatetags/tom_common_extras.py
+++ b/tom_common/templatetags/tom_common_extras.py
@@ -21,3 +21,11 @@ def verbose_name(instance, field_name):
 @register.inclusion_tag('comments/list.html')
 def recent_comments(limit=10):
     return {'comment_list': Comment.objects.all().order_by('-submit_date')[:limit]}
+
+
+@register.filter
+def truncate_number(value):
+    try:
+        return '%.3f' % value
+    except:
+        return value

--- a/tom_targets/templates/tom_targets/partials/target_data.html
+++ b/tom_targets/templates/tom_targets/partials/target_data.html
@@ -1,10 +1,18 @@
-{% load tom_common_extras %}
+{% load tom_common_extras targets_extras %}
 <a href="{% url 'tom_targets:update' pk=target.id %}" title="Update target" class="btn  btn-primary">Update Target</a>
 <a href="{% url 'tom_targets:delete' pk=target.id %}" title="Delete target" class="btn  btn-warning">Delete Target</a>
 <dl class="row">
   {% for key, value in target.as_dict.items %}
   <dt class="col-sm-6">{% verbose_name target key %}</dt>
-  <dd class="col-sm-6">{{ value }}</dd>
+  <dd class="col-sm-6">{{ value|truncate_number }}</dd>
+  {% if key == 'ra' %}
+    <dt class="col-sm-6">&nbsp;</dt>
+    <dd class="col-sm-6">{{ value|deg_to_sexigesimal:"hms" }}</dd>
+  {% endif%}
+  {% if key == 'dec' %}
+    <dt class="col-sm-6">&nbsp;</dt>
+    <dd class="col-sm-6">{{ value|deg_to_sexigesimal:"dms" }}</dd>
+  {% endif%}
   {% endfor %}
 </dl>
 <dl class="row">

--- a/tom_targets/templatetags/targets_extras.py
+++ b/tom_targets/templatetags/targets_extras.py
@@ -1,8 +1,9 @@
 from django import template
 from dateutil.parser import parse
-
 from plotly import offline
 import plotly.graph_objs as go
+from astropy import units as u
+from astropy.coordinates import Angle
 
 from tom_targets.models import Target
 from tom_targets.forms import TargetVisibilityForm
@@ -62,3 +63,16 @@ def target_plan(context):
         'target': context['object'],
         'visibility_graph': visibility_graph
     }
+
+
+@register.filter
+def deg_to_sexigesimal(value, fmt):
+    a = Angle(value, unit=u.degree)
+    if fmt == 'hms':
+        return '{0}:{1}:{2}'.format(a.hms.h, a.hms.m, '%.3f' % a.hms.s)
+    elif fmt == 'dms':
+        rep = a.signed_dms
+        sign = '-' if rep.sign < 0 else '+'
+        return '{0}{1}:{2}:{3}'.format(sign, rep.d, rep.m, '%.3f' % rep.s)
+    else:
+        return 'fmt must be "hms" or "dms"'

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -31,13 +31,60 @@ class TestTargetDetail(TestCase):
         response = self.client.get(reverse('targets:detail', kwargs={'pk': self.nst.id}))
         self.assertContains(response, self.nst.id)
 
-    def test_sidereal_target_create(self):
+
+class TestTargetCreate(TestCase):
+    def setUp(self):
+        user = User.objects.create(username='testuser')
+        self.client.force_login(user)
+
+    def test_target_create_form(self):
         response = self.client.get(reverse('targets:create'))
         self.assertContains(response, Target.SIDEREAL)
-
-    def test_non_sidereal_target_create(self):
-        response = self.client.get(reverse('targets:create'))
         self.assertContains(response, Target.NON_SIDEREAL)
+
+    def test_create_target(self):
+        target_data = {
+            'name': 'test_target',
+            'identifier': 'test_target_id',
+            'type': Target.SIDEREAL,
+            'ra': 123.456,
+            'dec': -32.1,
+            'targetextra_set-TOTAL_FORMS': 1,
+            'targetextra_set-INITIAL_FORMS': 0,
+            'targetextra_set-MIN_NUM_FORMS': 0,
+            'targetextra_set-MAX_NUM_FORMS': 1000,
+            'targetextra_set-0-key': None,
+            'targetextra_set-0-value': None,
+
+        }
+        response = self.client.post(reverse('targets:create'), data=target_data, follow=True)
+        self.assertContains(response, target_data['name'])
+        self.assertTrue(Target.objects.filter(name=target_data['name']).exists())
+
+    def test_create_target_sexigesimal(self):
+        """
+        Using coordinates for Messier 1
+        """
+        target_data = {
+            'name': 'test_target',
+            'identifier': 'test_target_id',
+            'type': Target.SIDEREAL,
+            'ra': '05:34:31.94',
+            'dec': '+22:00:52.2',
+            'targetextra_set-TOTAL_FORMS': 1,
+            'targetextra_set-INITIAL_FORMS': 0,
+            'targetextra_set-MIN_NUM_FORMS': 0,
+            'targetextra_set-MAX_NUM_FORMS': 1000,
+            'targetextra_set-0-key': None,
+            'targetextra_set-0-value': None,
+
+        }
+        response = self.client.post(reverse('targets:create'), data=target_data, follow=True)
+        self.assertContains(response, target_data['name'])
+        target = Target.objects.get(name=target_data['name'])
+        # Coordinates according to simbad
+        self.assertAlmostEqual(target.ra, 83.63308, places=4)
+        self.assertAlmostEqual(target.dec, 22.0145, places=4)
 
 
 class TestTargetSearch(TestCase):


### PR DESCRIPTION
This commit allows users to input ra/dec as sexigesimal when creating a
target, as well as displaying both deg and sexigesimal respresentaions
of ra/dec on the target detail page.