### PR TITLE
Add configurable auth strategy

### DIFF
--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -64,6 +64,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'tom_common.middleware.ExternalServiceMiddleware',
+    'tom_common.middleware.AuthStrategyMiddlware',
 ]
 
 ROOT_URLCONF = 'tom_common.urls'
@@ -180,6 +181,14 @@ FACILITIES = {
         'api_key': '',
     }
 }
+
+# Authentication strategy can either be LOCKED (required login for all views)
+# or READ_ONLY (read only access to views)
+AUTH_STRATEGY = 'READ_ONLY'
+
+# URLs that should be allowed access even with AUTH_STRATEGY = LOCKED
+# for example: OPEN_URLS = ['/', '/about']
+OPEN_URLS = []
 
 HOOKS = {
     'target_post_save': 'tom_common.hooks.target_post_save',

--- a/tom_common/tests.py
+++ b/tom_common/tests.py
@@ -1,4 +1,5 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
+
 from django.contrib.auth.models import User
 from django.urls import reverse
 
@@ -67,3 +68,18 @@ class TestUserManagement(TestCase):
         self.assertContains(response, 'Profile updated')
         user.refresh_from_db()
         self.assertEqual(user.first_name, 'Luke')
+
+
+class TestAuthScheme(TestCase):
+    @override_settings(AUTH_STRATEGY='LOCKED')
+    def test_user_cannot_access_view(self):
+        response = self.client.get(reverse('tom_targets:list'))
+        self.assertRedirects(
+            response, reverse('login') + '?next=' + reverse('tom_targets:list'), status_code=302
+        )
+
+    @override_settings(AUTH_STRATEGY='READ_ONLY')
+    def test_user_can_access_view(self):
+        response = self.client.get(reverse('tom_targets:list'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Add a target')

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -195,6 +195,14 @@ FACILITIES = {
     },
 }
 
+# Authentication strategy can either be LOCKED (required login for all views)
+# or READ_ONLY (read only access to views)
+AUTH_STRATEGY = 'READ_ONLY'
+
+# URLs that should be allowed access even with AUTH_STRATEGY = LOCKED
+# for example: OPEN_URLS = ['/', '/about']
+OPEN_URLS = []
+
 HOOKS = {
     'target_post_save': 'tom_common.hooks.target_post_save',
     'observation_change_state': 'tom_common.hooks.observation_change_state'


### PR DESCRIPTION
This commit allows configuring the authentication strategy for the
entire TOM. Currently there are 2 values: READ_ONLY and LOCKED, the
latter which will require authentication to access any view (besides
login and a configurable list of exceptions).