### PR TITLE
Closes the loop on issue #22

### DIFF
--- a/tom_alerts/templates/tom_alerts/query_result.html
+++ b/tom_alerts/templates/tom_alerts/query_result.html
@@ -6,6 +6,7 @@
   {% csrf_token %}
   <div class="">
     <input type="hidden" name="broker" value="{{ query.broker }}"/>
+    <input type="hidden" name="query_id" value="{{ query.id }}"/>
     <input type="submit" value="Create Targets" class="btn btn-primary"/>
   </div>
   <table class="table table-striped">

--- a/tom_alerts/tests/tests_generic.py
+++ b/tom_alerts/tests/tests_generic.py
@@ -179,13 +179,14 @@ class TestBrokerViews(TestCase):
         self.assertEqual(broker_query.parameters_as_dict['name'], update_data['name'])
 
     def test_create_target(self):
-        BrokerQuery.objects.create(
+        query = BrokerQuery.objects.create(
             name='find hoth',
             broker='TEST',
             parameters='{"name": "Hoth"}',
         )
         post_data = {
             'broker': 'TEST',
+            'query_id': query.id,
             'alerts': [2]
         }
         response = self.client.post(reverse('tom_alerts:create-target'), data=post_data)
@@ -194,13 +195,14 @@ class TestBrokerViews(TestCase):
         self.assertRedirects(response, reverse('tom_targets:detail', kwargs={'pk': Target.objects.first().id}))
 
     def test_create_multiple_targets(self):
-        BrokerQuery.objects.create(
+        query = BrokerQuery.objects.create(
             name='find anything',
             broker='TEST',
             parameters='{"score__gt": "19"}'
         )
         post_data = {
             'broker': 'TEST',
+            'query_id': query.id,
             'alerts': [1, 2]
         }
         response = self.client.post(reverse('tom_alerts:create-target'), data=post_data)

--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -114,13 +114,11 @@ class RunQueryView(TemplateView):
 
 class CreateTargetFromAlertView(LoginRequiredMixin, View):
     def post(self, request, *args, **kwargs):
-        print(self.request.POST)
         query_id = self.request.POST['query_id']
         broker_name = self.request.POST['broker']
         broker_class = get_service_class(broker_name)
         alerts = self.request.POST.getlist('alerts')
         if not alerts:
-            print('here')
             messages.warning(request, 'Please select at least one alert from which to create a target.')
             return redirect(reverse('tom_alerts:run', kwargs={'pk': query_id}))
         for alert in alerts:

--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -114,12 +114,15 @@ class RunQueryView(TemplateView):
 
 class CreateTargetFromAlertView(LoginRequiredMixin, View):
     def post(self, request, *args, **kwargs):
+        print(self.request.POST)
+        query_id = self.request.POST['query_id']
         broker_name = self.request.POST['broker']
         broker_class = get_service_class(broker_name)
         alerts = self.request.POST.getlist('alerts')
         if not alerts:
+            print('here')
             messages.warning(request, 'Please select at least one alert from which to create a target.')
-            return redirect(request.META.get('HTTP_REFERER', '/'))
+            return redirect(reverse('tom_alerts:run', kwargs={'pk': query_id}))
         for alert in alerts:
             alert = broker_class().fetch_alert(alert)
             target = broker_class().to_target(alert)

--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -119,7 +119,10 @@ class ReducedDatum(models.Model):
     data_product = models.ForeignKey(DataProduct, null=True, on_delete=models.CASCADE)
     data_type = models.CharField(
         max_length=100,
-        choices=getattr(settings, 'DATA_TYPES', ('', '')),
+        choices=getattr(settings, 'DATA_TYPES', (
+            ('SPECTROSCOPY', 'Spectroscopy'),
+            ('PHOTOMETRY', 'Photometry')
+        )),
         default=''
     )
     timestamp = models.DateTimeField(null=False, blank=False, db_index=True)

--- a/tom_dataproducts/views.py
+++ b/tom_dataproducts/views.py
@@ -27,7 +27,9 @@ class DataProductSaveView(LoginRequiredMixin, View):
         service_class = get_service_class(request.POST['facility'])
         observation_record = ObservationRecord.objects.get(pk=kwargs['pk'])
         products = request.POST.getlist('products')
-        if products[0] == 'ALL':
+        if not products:
+            messages.warning(request, 'No products were saved, please select at least one dataproduct')
+        elif products[0] == 'ALL':
             products = service_class().save_data_products(observation_record)
             messages.success(request, 'Saved all available data products')
         else:


### PR DESCRIPTION
Fixes crash when submitting multiselect forms with no selections in dataproducts and alerts
Adds saner redirection when creating a target from a single alert

Fixes #22 