### PR TITLE
Feature/easy extra fields

### DIFF
--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -189,6 +189,7 @@ FACILITIES = {
 #     {'name': 'redshift', 'type': 'number'},
 #     {'name': 'nickname', 'type': 'string'}
 # ]
+EXTRA_FIELDS = []
 
 # Authentication strategy can either be LOCKED (required login for all views)
 # or READ_ONLY (read only access to views)

--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -182,11 +182,13 @@ FACILITIES = {
     }
 }
 
-# Define extra target fields here.
-EXTRA_FIELDS = [
-    {'name': 'redshift', 'type': 'number'},
-    {'name': 'color', 'type': 'string'}
-]
+# Define extra target fields here. Types are either "number" or "string".
+# TODO: Add link to documentation
+# For example:
+# EXTRA_FIELDS = [
+#     {'name': 'redshift', 'type': 'number'},
+#     {'name': 'nickname', 'type': 'string'}
+# ]
 
 # Authentication strategy can either be LOCKED (required login for all views)
 # or READ_ONLY (read only access to views)

--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -174,13 +174,19 @@ LOGGING = {
     }
 }
 
-TARGET_TYPE = 'NON_SIDEREAL'
+TARGET_TYPE = 'SIDEREAL'
 FACILITIES = {
     'LCO': {
         'portal_url': 'https://observe.lco.global',
         'api_key': os.getenv('LCO_API_KEY', ''),
     }
 }
+
+# Define extra target fields here.
+EXTRA_FIELDS = [
+    {'name': 'redshift', 'type': 'number'},
+    {'name': 'color', 'type': 'string'}
+]
 
 # Authentication strategy can either be LOCKED (required login for all views)
 # or READ_ONLY (read only access to views)

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -202,6 +202,7 @@ FACILITIES = {
 #     {'name': 'redshift', 'type': 'number'},
 #     {'name': 'nickname', 'type': 'string'}
 # ]
+EXTRA_FIELDS = []
 
 # Authentication strategy can either be LOCKED (required login for all views)
 # or READ_ONLY (read only access to views)

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -195,6 +195,14 @@ FACILITIES = {
     },
 }
 
+# Define extra target fields here. Types are either "number" or "string".
+# TODO: Add link to documentation
+# For example:
+# EXTRA_FIELDS = [
+#     {'name': 'redshift', 'type': 'number'},
+#     {'name': 'nickname', 'type': 'string'}
+# ]
+
 # Authentication strategy can either be LOCKED (required login for all views)
 # or READ_ONLY (read only access to views)
 AUTH_STRATEGY = 'READ_ONLY'

--- a/tom_targets/filters.py
+++ b/tom_targets/filters.py
@@ -1,12 +1,26 @@
 import django_filters
 from django.db.models import Q
+from django.conf import settings
 
 from tom_targets.models import Target
 
 
+def filter_type_for_field(field_type):
+    if field_type == 'number':
+        return django_filters.RangeFilter
+    else:
+        return django_filters.CharFilter
+
+
 class TargetFilter(django_filters.FilterSet):
-    key = django_filters.CharFilter(field_name='targetextra__key', label='Key')
-    value = django_filters.CharFilter(field_name='targetextra__value', label='Value')
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in settings.EXTRA_FIELDS:
+            filter_type = filter_type_for_field(field['type'])
+            new_filter = filter_type(field_name=field['name'], method='filter_extra')
+            new_filter.parent = self
+            self.filters[field['name']] = new_filter
+
     identifier = django_filters.CharFilter(field_name='identifier', lookup_expr='icontains')
     name = django_filters.CharFilter(field_name='name', method='filter_name')
 
@@ -15,6 +29,13 @@ class TargetFilter(django_filters.FilterSet):
             Q(name__icontains=value) | Q(name2__icontains=value) | Q(name3__icontains=value)
         )
 
+    def filter_extra(self, queryset, name, value):
+        queryset = queryset.filter(targetextra__key=name)
+        if isinstance(value, slice):
+            return queryset.filter(targetextra__value__gte=value.start, targetextra__value__lte=value.stop)
+        else:
+            return queryset.filter(targetextra__value__icontains=value)
+
     class Meta:
         model = Target
-        fields = ['type', 'identifier', 'name', 'key', 'value']
+        fields = ['type', 'identifier', 'name']

--- a/tom_targets/forms.py
+++ b/tom_targets/forms.py
@@ -55,10 +55,10 @@ class TargetForm(forms.ModelForm):
         if commit:
             for field in settings.EXTRA_FIELDS:
                 if self.cleaned_data.get(field['name']):
-                    TargetExtra.objects.create(
+                    TargetExtra.objects.update_or_create(
                             target=instance,
                             key=field['name'],
-                            value=self.cleaned_data[field['name']]
+                            defaults={'value': self.cleaned_data[field['name']]}
                     )
         return instance
 

--- a/tom_targets/templates/tom_targets/target_form.html
+++ b/tom_targets/templates/tom_targets/target_form.html
@@ -19,8 +19,6 @@
   {% endif %}
   {% csrf_token %}
   {% bootstrap_form form %}
-  <p>Extra Data</p>
-  {% bootstrap_formset extra_form %}
   {% buttons %}
     <button type="submit" class="btn btn-primary">
       Submit

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -34,15 +34,6 @@ class TestTargetCreate(TestCase):
     def setUp(self):
         user = User.objects.create(username='testuser')
         self.client.force_login(user)
-        self.extra_form_data = {
-            'targetextra_set-TOTAL_FORMS': 1,
-            'targetextra_set-INITIAL_FORMS': 0,
-            'targetextra_set-MIN_NUM_FORMS': 0,
-            'targetextra_set-MAX_NUM_FORMS': 1000,
-            'targetextra_set-0-key': None,
-            'targetextra_set-0-value': None,
-        }
-
 
     def test_target_create_form(self):
         response = self.client.get(reverse('targets:create'))
@@ -56,7 +47,6 @@ class TestTargetCreate(TestCase):
             'type': Target.SIDEREAL,
             'ra': 123.456,
             'dec': -32.1,
-            **self.extra_form_data
         }
         response = self.client.post(reverse('targets:create'), data=target_data, follow=True)
         self.assertContains(response, target_data['name'])
@@ -72,7 +62,6 @@ class TestTargetCreate(TestCase):
             'type': Target.SIDEREAL,
             'ra': '05:34:31.94',
             'dec': '+22:00:52.2',
-            **self.extra_form_data
 
         }
         response = self.client.post(reverse('targets:create'), data=target_data, follow=True)
@@ -91,7 +80,6 @@ class TestTargetCreate(TestCase):
             'ra': 113.456,
             'dec': -22.1,
             'wins': 50.0,
-            **self.extra_form_data
         }
         response = self.client.post(reverse('targets:create'), data=target_data, follow=True)
         self.assertContains(response, target_data['name'])

--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -76,7 +76,12 @@ class TargetCreateView(LoginRequiredMixin, CreateView):
 
 class TargetUpdateView(LoginRequiredMixin, UpdateView):
     model = Target
-    fields = '__all__'
+
+    def get_form_class(self):
+        if self.object.type == Target.SIDEREAL:
+            return SiderealTargetCreateForm
+        elif self.object.type == Target.NON_SIDEREAL:
+            return NonSiderealTargetCreateForm
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -49,7 +49,6 @@ class TargetCreateView(LoginRequiredMixin, CreateView):
     def get_context_data(self, **kwargs):
         context = super(TargetCreateView, self).get_context_data(**kwargs)
         context['type_choices'] = Target.TARGET_TYPES
-        context['extra_form'] = TargetExtraFormset()
         return context
 
     def get_form_class(self):
@@ -65,14 +64,6 @@ class TargetCreateView(LoginRequiredMixin, CreateView):
             self.initial['type'] = Target.NON_SIDEREAL
             return NonSiderealTargetCreateForm
 
-    def form_valid(self, form):
-        super().form_valid(form)
-        extra = TargetExtraFormset(self.request.POST)
-        if extra.is_valid():
-            extra.instance = self.object
-            extra.save()
-        return redirect(self.get_success_url())
-
 
 class TargetUpdateView(LoginRequiredMixin, UpdateView):
     model = Target
@@ -82,18 +73,6 @@ class TargetUpdateView(LoginRequiredMixin, UpdateView):
             return SiderealTargetCreateForm
         elif self.object.type == Target.NON_SIDEREAL:
             return NonSiderealTargetCreateForm
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['extra_form'] = TargetExtraFormset(instance=self.object)
-        return context
-
-    def form_valid(self, form):
-        super().form_valid(form)
-        extra = TargetExtraFormset(self.request.POST, instance=self.object)
-        if extra.is_valid():
-            extra.save()
-        return redirect(self.get_success_url())
 
 
 class TargetDeleteView(LoginRequiredMixin, DeleteView):


### PR DESCRIPTION
This allows a declarative way of adding custom fields to targets. It still uses the underlying key/value model but the defined fields should look and act the same as the normal model fields.

This should work for the "adding redshift" use case from Snex 2.0 without the need of copying entire models. 