### PR TITLE
Fix update num targets

### DIFF
--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -30,7 +30,7 @@ class TargetListView(PermissionListMixin, FilterView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context['target_count'] = context['object_list'].count()
+        context['target_count'] = context['paginator'].count
         return context
 
 


### PR DESCRIPTION
Previous fix was wrong. It only counted the number of targets displayed in the list, which maxes out at 25 a page. Now corrected.