### PR TITLE
Truncate long names in the /dataproducts/data/ view to avoid overlapping

### DIFF
--- a/tom_dataproducts/templates/tom_dataproducts/dataproduct_list.html
+++ b/tom_dataproducts/templates/tom_dataproducts/dataproduct_list.html
@@ -27,16 +27,16 @@
       <tbody>
         {% for product in object_list %}
         <tr>
-          <td><a href="{{ product.data.url }}">{{ product.get_file_name }}</a></th>
-          <td><a href="{% url 'tom_targets:detail' product.target.id %}">{{ product.target.identifier }}</a></td>
+          <td><a href="{{ product.data.url }}">{{ product.get_file_name|truncatechars:40 }}</a></th>
+          <td><a href="{% url 'tom_targets:detail' product.target.id %}">{{ product.target.identifier|truncatechars:40 }}</a></td>
           {% if product.observation_record.id %}
-          <td><a href="{% url 'tom_observations:detail' product.observation_record.id %}">{{ product.observation_record }}</a></td>
+          <td><a href="{% url 'tom_observations:detail' product.observation_record.id %}">{{ product.observation_record|truncatechars:40 }}</a></td>
           {% else %}
           <td></td>
           {% endif %}
           <td>
             {% for group in product.group.all %}
-            <a href="{% url 'tom_dataproducts:group-detail' group.id %}">{{ group.name }}</a>
+            <a href="{% url 'tom_dataproducts:group-detail' group.id %}">{{ group.name|truncatechars:40 }}</a>
             {% endfor %}
           </td>
           <td>


### PR DESCRIPTION
Presently long names for data products cause the table at `/dataproducts/data/` to overlap the filters and list of data product groups:
![before](https://user-images.githubusercontent.com/12171762/61121448-26d4ad80-a497-11e9-85c9-b90f9bf531d2.png)

This patch truncates names after 40 characters:
![after](https://user-images.githubusercontent.com/12171762/61121458-2cca8e80-a497-11e9-81b1-d96e38dae662.png)
