### PR TITLE
Added plotly attribute to account for 4.0.0 update

### DIFF
--- a/tom_targets/templatetags/targets_extras.py
+++ b/tom_targets/templatetags/targets_extras.py
@@ -90,6 +90,7 @@ def target_distribution(targets):
                 'type': 'mollweide',
             },
             'showcoastlines': False,
+            'showland': False,
             'lonaxis': {
                 'showgrid': True,
                 'range': [0, 360],


### PR DESCRIPTION
As of Plotly 4.0.0, land masses are shown by default on geo plots. While we should consider pinning the version, this will correct the issue for anyone currently on the new Plotly version.