### PR TITLE
Make extra field values in Target.extra_fields the correct type

### DIFF
--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -170,7 +170,9 @@ class Target(models.Model):
     @property
     def extra_fields(self):
         defined_extras = [extra_field['name'] for extra_field in settings.EXTRA_FIELDS]
-        return {te.key: te.value for te in self.targetextra_set.filter(key__in=defined_extras)}
+        types = {extra_field['name']: extra_field['type'] for extra_field in settings.EXTRA_FIELDS}
+        return {te.key: te.typed_value(types[te.key])
+                for te in self.targetextra_set.filter(key__in=defined_extras)}
 
     @property
     def tags(self):

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -161,6 +161,12 @@ class TestTargetCreate(TestCase):
             TargetExtra.objects.get(target=target, key='author').typed_value('string'),
             'Dr. Suess'
         )
+        # Check extra_fields property converts values to the correct type
+        self.assertIsInstance(target.extra_fields, dict)
+        self.assertIsInstance(target.extra_fields['wins'], float)
+        self.assertIsInstance(target.extra_fields['checked'], bool)
+        self.assertIsInstance(target.extra_fields['birthdate'], datetime)
+        self.assertIsInstance(target.extra_fields['author'], str)
 
     def test_target_save_programmatic_extras(self):
         target = SiderealTargetFactory.create()


### PR DESCRIPTION
Previously the `extra_fields` dictionary for the `Target` model had all
values as strings. E.g. `'False'` (as a string) instead of `False` for a
boolean field. This commit makes sure the types are correct.

(Note: The only place this dictionary was used in the `tom_base` code is
in the target detail template. The template still displays properly
after this change.)