### PR TITLE
Added placeholder identifier for targets without one on target list page

### DIFF
--- a/tom_alerts/brokers/antares.py
+++ b/tom_alerts/brokers/antares.py
@@ -27,9 +27,10 @@ class AntaresBroker(GenericBroker):
 
     def __init__(self, *args, **kwargs):
         try:
+            antares_creds = settings.BROKER_CREDENTIALS['antares']
             self.config = {
-                'api_key': settings.BROKERS['antares']['api_key'],
-                'api_secret': settings.BROKERS['antares']['api_secret']
+                'api_key': antares_creds['api_key'],
+                'api_secret': antares_creds['api_secret']
             }
 
         except KeyError:

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -219,6 +219,10 @@ TOM_ALERT_CLASSES = [
     'tom_alerts.brokers.antares.AntaresBroker'
 ]
 
+BROKER_CREDENTIALS = {
+
+}
+
 # Define extra target fields here. Types can be any of "number", "string", "boolean" or "datetime"
 # See https://tomtoolkit.github.io/docs/target_fields for documentation on this feature
 # For example:

--- a/tom_targets/templates/tom_targets/target_list.html
+++ b/tom_targets/templates/tom_targets/target_list.html
@@ -28,7 +28,7 @@
         <select name="grouping" class="form-control w-25 ml-1">
           {% for grouping in groupings %}
           <option value="{{ grouping.id }}">{{ grouping.name }}</option>
-          {% endfor %} 
+          {% endfor %}
         </select>
         <input type="hidden" value="{{ query_string }}" name="query_string">
         <input type="hidden" value="False" id="isSelectAll" name="isSelectAll">
@@ -54,8 +54,15 @@
           {% for target in object_list %}
           <tr>
             <td><input type="checkbox" name="selected-target" value="{{ target.id }}" onClick="single_select()"/></td>
-            <td><a href="{% url 'targets:detail' target.id %}"
-                title="{{ target.identifier }}">{{ target.identifier }}</a></td>
+            <td>
+              <a href="{% url 'targets:detail' target.id %}" title="{{ target.identifier }}">
+                {% if not target.identifier %}
+                  (none)
+                {% else %}
+                  {{ target.identifier }}
+                {% endif %}
+              </a>
+            </td>
             <td>{{ target.name }}</td>
             <td>{{ target.get_type_display }}</td>
             {% if request.GET.type == 'SIDEREAL' %}


### PR DESCRIPTION
At present, if a target is created without an identifier (either programmatically or via CSV import), it is not selectable in the target list view, as the identifier is the link to the detail page. Additionally, when updating reduced data from brokers, the update fails with a somewhat nonsensical error message if the BROKER_CREDENTIALS are not present in settings.py

This change adds a placeholder for targets without identifiers in the list view, adds an empty BROKER_CREDENTIALS in settings.tmpl, and accesses the antares credentials in such a way as to raise the associated ImproperlyConfigured error.