### PR TITLE
Changed extension header for identifying valid fits files

### DIFF
--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -43,6 +43,7 @@ def find_img_size(filename):
 
 def is_fits_image_file(file):
     filetype = magic.from_file(file.path, mime=True)
+    print(filetype)
     if filetype == 'image/fits':
         try:
             hdul = fits.open(file.path)

--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -42,17 +42,13 @@ def find_img_size(filename):
 
 
 def is_fits_image_file(file):
-    filetype = magic.from_file(file.path, mime=True)
-    print(filetype)
-    if filetype == 'image/fits':
-        try:
-            hdul = fits.open(file.path)
-        except OSError:  # OSError is raised if file is not FITS format
-            return False
-        for hdu in hdul:
-            if hdu.header.get('EXTNAME') == 'SCI':
-                return True
+    try:
+        hdul = fits.open(file.path)
+    except OSError:  # OSError is raised if file is not FITS format
         return False
+    for hdu in hdul:
+        if hdu.header.get('EXTNAME') == 'SCI':
+            return True
     return False
 
 

--- a/tom_observations/templatetags/observation_extras.py
+++ b/tom_observations/templatetags/observation_extras.py
@@ -91,6 +91,7 @@ def observation_distribution(observations):
                 'type': 'mollweide',
             },
             'showcoastlines': False,
+            'showland': False,
             'lonaxis': {
                 'showgrid': True,
                 'range': [0, 360],


### PR DESCRIPTION
At present, thumbnails cannot be generated for raw images, only for LCO-reduced images. This PR does the following:

- Changes the header used to identify valid images to `EXTNAME` instead of `XTENSION`, which appears to be a BANZAI-generated header keyword.
- Uses magic to validate filetype instead of relying solely on astropy's fits library, which we do elsewhere.

It also addresses the Plotly update separating the properties for coastline and landmass appearances for the observation distribution plot.