### PR TITLE
Make sure DataProduct.get_preview() does not error when a thumbnail cannot be drawn

### DIFF
--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -130,6 +130,8 @@ class DataProduct(models.Model):
                     self.thumbnail.save(filename, File(f), save=True)
                     self.save()
                 tmpfile.close()
+        if not self.thumbnail:
+            return ''
         return self.thumbnail.url
 
     def create_thumbnail(self, width=None, height=None):


### PR DESCRIPTION
This method returns the URL for a thumbnail preview of a FITS file, and
would previously raise an exception when called on a non-FITS file. This
commit makes an empty string be returned in such cases, which avoids the
need to check filetype before calling from templates etc.