### PR TITLE
Use a textarea for string extra fields in target create/update form

### DIFF
--- a/tom_targets/forms.py
+++ b/tom_targets/forms.py
@@ -18,7 +18,7 @@ def extra_field_to_form_field(field_type):
     elif field_type == 'datetime':
         return forms.DateTimeField(required=False)
     elif field_type == 'string':
-        return forms.CharField(required=False)
+        return forms.CharField(required=False, widget=forms.Textarea)
     else:
         raise ValueError(
             'Invalid field type {}. Field type must be one of: number, boolean, datetime string'.format(field_type)


### PR DESCRIPTION
Change the widget for extra fields of type 'string' to a `<textarea>` instead of the default text input.

This makes it possible to use extra fields for long-form text data, and for the text to include newlines.
For example, the new asteroid tracker application uses extra fields in the TOM to store detailed information about a target in markdown, which is too long to reasonably edit in a normal textbox. It is anticipated that other projects could also benefit from storing long-form text in extra fields.

Existing functionality is not affected, and the other text inputs on the form remain the same.