### PR TITLE
Fix/data upload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'gsselect',
         'fits2image',
         'specutils',
-        'python-magic',
         'antares-client',
         'rise-set'
     ],

--- a/tom_dataproducts/data_processor.py
+++ b/tom_dataproducts/data_processor.py
@@ -37,9 +37,6 @@ class DataProcessor():
         """
 
         mimetype = mimetypes.guess_type(data_product.data.path)[0]
-        print(mimetype)
-        print(mimetypes.knownfiles)
-        print(mimetypes.read_mime_types(data_product.data.path))
         if mimetype in FITS_MIMETYPES:
             return self._process_spectrum_from_fits(data_product)
         elif mimetype in PLAINTEXT_MIMETYPES:

--- a/tom_dataproducts/data_processor.py
+++ b/tom_dataproducts/data_processor.py
@@ -37,6 +37,7 @@ class DataProcessor():
         """
 
         mimetype = mimetypes.guess_type(data_product.data.path)[0]
+        print(mimetype)
         if mimetype in FITS_MIMETYPES:
             return self._process_spectrum_from_fits(data_product)
         elif mimetype in PLAINTEXT_MIMETYPES:

--- a/tom_dataproducts/data_processor.py
+++ b/tom_dataproducts/data_processor.py
@@ -39,6 +39,7 @@ class DataProcessor():
         mimetype = mimetypes.guess_type(data_product.data.path)[0]
         print(mimetype)
         print(mimetypes.knownfiles)
+        print(mimetypes.read_mime_types(data_product.data.path))
         if mimetype in FITS_MIMETYPES:
             return self._process_spectrum_from_fits(data_product)
         elif mimetype in PLAINTEXT_MIMETYPES:

--- a/tom_dataproducts/data_processor.py
+++ b/tom_dataproducts/data_processor.py
@@ -1,4 +1,5 @@
-import magic
+import mimetypes
+from datetime import datetime
 
 from astropy.time import Time, TimezoneInfo
 from astropy import units
@@ -7,64 +8,72 @@ from astropy.wcs import WCS
 from specutils import Spectrum1D
 import numpy as np
 
-from tom_observations.facility import get_service_class
+from tom_observations.facility import get_service_class, get_service_classes
 from .exceptions import InvalidFileFormatException
+
+
+FITS_MIMETYPES = ['image/fits', 'application/fits']
+PLAINTEXT_MIMETYPES = ['text/plain', 'text/csv']
+DEFAULT_WAVELENGTH_UNITS = units.angstrom
+DEFAULT_FLUX_CONSTANT = units.erg / units.cm ** 2 / units.second / units.angstrom
 
 
 class DataProcessor():
 
-    def process_spectroscopy(self, data_product, facility):
+    def process_spectroscopy(self, data_product):
         """
         Routes a spectrum processing call to a method specific to a file-format.
 
-        Parameters
-        ----------
-        data_product : tom_dataproducts.models.DataProduct
-            Spectroscopic DataProduct which will be processed into a Spectrum1D
-        facility : str
-            The name of the facility from which the data was taken, and should match the key in the FACILITY property in
-            the TOM settings.
+        :param data_product: Spectroscopic DataProduct which will be processed into a Spectrum1D
+        :type data_product: tom_dataproducts.models.DataProduct
 
-        Returns
-        -------
-        specutils.Spectrum1D
-            Spectrum1D object containing the data from the DataProduct
+        :returns: Spectrum1D object containing the data from the DataProduct
+        :rtype: specutils.Spectrum1D
 
-        Raises
-        ------
-        InvalidFileFormatException
+        :returns: Datetime of observation
+        :rtype: AstroPy.Time
+
+        :raises: InvalidFileFormatException
         """
 
-        filetype = magic.from_file(data_product.data.path, mime=True)
-        if filetype == 'image/fits':
-            return self._process_spectrum_from_fits(data_product, facility)
-        elif filetype == 'text/plain':
-            return self._process_spectrum_from_plaintext(data_product, facility)
+        mimetype = mimetypes.guess_type(data_product.data.path)[0]
+        if mimetype in FITS_MIMETYPES:
+            return self._process_spectrum_from_fits(data_product)
+        elif mimetype in PLAINTEXT_MIMETYPES:
+            return self._process_spectrum_from_plaintext(data_product)
         else:
             raise InvalidFileFormatException('Unsupported file type')
 
-    def _process_spectrum_from_fits(self, data_product, facility):
+    def _process_spectrum_from_fits(self, data_product):
         """
         Processes the data from a spectrum from a fits file into a Spectrum1D object, which can then be serialized and
         stored as a ReducedDatum for further processing or display. File is read using specutils as specified in the
         below documentation.
         # https://specutils.readthedocs.io/en/doc-testing/specutils/read_fits.html
 
-        Parameters
-        ----------
-        data_product : tom_dataproducts.models.DataProduct
-            Spectroscopic DataProduct which will be processed into a Spectrum1D
-        facility : str
-            The name of the facility from which the data was taken, and should match the key in the FACILITY property in
-            the TOM settings.
+        :param data_product: Spectroscopic DataProduct which will be processed into a Spectrum1D
+        :type data_product: tom_dataproducts.models.DataProduct
 
-        Returns
-        -------
-        specutils.Spectrum1D
-            Spectrum1D object containing the data from the DataProduct
+        :returns: Spectrum1D object containing the data from the DataProduct
+        :rtype: specutils.Spectrum1D
+
+        :returns: Datetime of observation, if it is in the header and the file is from a supported facility, current
+            datetime otherwise
+        :rtype: AstroPy.Time
         """
 
+        # TODO: Add methods to Gemini, SOAR
         flux, header = fits.getdata(data_product.data.path, header=True)
+
+        for facility_class in get_service_classes():
+            facility = get_service_class(facility_class)()
+            if facility.is_fits_facility(header):
+                flux_constant = facility.get_flux_constant()
+                date_obs = facility.get_date_obs(header)
+                break
+        else:
+            flux_constant = DEFAULT_FLUX_CONSTANT
+            date_obs = datetime.now()
 
         dim = len(flux.shape)
         if dim == 3:
@@ -73,58 +82,69 @@ class DataProcessor():
             flux = flux[0, :]
         header['CUNIT1'] = 'Angstrom'
         wcs = WCS(header=header)
-        flux = flux * get_service_class(facility)().get_flux_constant()
+        flux = flux * flux_constant
 
         spectrum = Spectrum1D(flux=flux, wcs=wcs)
 
-        return spectrum
+        return spectrum, Time(date_obs).to_datetime()
 
-    def _process_spectrum_from_plaintext(self, data_product, facility):
+    def _process_spectrum_from_plaintext(self, data_product):
         """
         Processes the data from a spectrum from a plaintext file into a Spectrum1D object, which can then be serialized
         and stored as a ReducedDatum for further processing or display. File is read using astropy as specified in
         the below documentation. The file is expected to be a multi-column delimited file, with headers for wavelength
-        and flux.
+        and flux. The file also requires comments containing, at minimum, 'DATE-OBS: [value]', where value is an
+        Astropy Time module-readable date. It can optionally contain 'FACILITY: [value]', where the facility is a string
+        matching the name of a valid facility in the TOM.
         # http://docs.astropy.org/en/stable/io/ascii/read.html
 
         Parameters
         ----------
-        data_product : tom_dataproducts.models.DataProduct
-            Spectroscopic DataProduct which will be processed into a Spectrum1D
-        facility : str
-            The name of the facility from which the data was taken, and should match the key in the FACILITY property in
-            the TOM settings.
+        :param data_product: Spectroscopic DataProduct which will be processed into a Spectrum1D
+        :type data_product: tom_dataproducts.models.DataProduct
 
-        Returns
-        -------
-        specutils.Spectrum1D
-            Spectrum1D object containing the data from the DataProduct
+        :returns: Spectrum1D object containing the data from the DataProduct
+        :rtype: specutils.Spectrum1D
+
+        :returns: Datetime of observation, if it is in the comments and the file is from a supported facility, current
+            datetime otherwise
+        :rtype: AstroPy.Time
         """
 
         data = ascii.read(data_product.data.path)
-        spectral_axis = np.array(data['wavelength']) * get_service_class(facility)().get_wavelength_units()
-        flux = np.array(data['flux']) * get_service_class(facility)().get_flux_constant()
+        facility_name = None
+        date_obs = datetime.now()
+        comments = data.meta.get('comments', [])
+
+        for comment in comments:
+            if 'date-obs' in comment.lower():
+                date_obs = comment.split(':')[1].strip()
+            if 'facility' in comment.lower():
+                facility_name = comment.split(':')[1].strip()
+
+        facility = get_service_class(facility_name)() if facility_name else None
+        wavelength_units = facility.get_wavelength_units() if facility else DEFAULT_WAVELENGTH_UNITS
+        flux_constant = facility.get_flux_constant() if facility else DEFAULT_FLUX_CONSTANT
+
+        spectral_axis = np.array(data['wavelength']) * wavelength_units
+        flux = np.array(data['flux']) * flux_constant
         spectrum = Spectrum1D(flux=flux, spectral_axis=spectral_axis)
 
-        return spectrum
+        return spectrum, Time(date_obs).to_datetime()
 
     def process_photometry(self, data_product):
         """
         Routes a photometry processing call to a method specific to a file-format.
 
-        Parameters
-        ----------
-        data_product : tom_dataproducts.models.DataProduct
-            Photometric DataProduct which will be processed into a dict
+        :param data_product: Photometric DataProduct which will be processed into a dict
+        :type data_product: DataProduct
 
-        Returns
-        -------
-        dict
-            python dict containing the data from the DataProduct
+        :returns: python dict containing the data from the DataProduct
+        :rtype: dict
         """
 
-        filetype = magic.from_file(data_product.data.path, mime=True)
-        if filetype == 'text/plain':
+        mimetype = mimetypes.guess_type(data_product.data.path)[0]
+        if mimetype in PLAINTEXT_MIMETYPES:
             return self._process_photometry_from_plaintext(data_product)
         else:
             raise InvalidFileFormatException('Unsupported file type')
@@ -136,15 +156,11 @@ class DataProcessor():
         is expected to be a multi-column delimited file, with headers for time, magnitude, filter, and error.
         # http://docs.astropy.org/en/stable/io/ascii/read.html
 
-        Parameters
-        ----------
-        data_product : tom_dataproducts.models.DataProduct
-            Photometric DataProduct which will be processed into a dict
+        :param data_product: Photometric DataProduct which will be processed into a dict
+        :type data_product: DataProduct
 
-        Returns
-        -------
-        dict
-            python dict containing the data from the DataProduct
+        :returns: python dict containing the data from the DataProduct
+        :rtype: dict
         """
 
         photometry = {}

--- a/tom_dataproducts/data_processor.py
+++ b/tom_dataproducts/data_processor.py
@@ -116,6 +116,8 @@ class DataProcessor():
         """
 
         data = ascii.read(data_product.data.path)
+        if len(data) < 1:
+            raise InvalidFileFormatException('Empty table or invalid file type')
         facility_name = None
         date_obs = datetime.now()
         comments = data.meta.get('comments', [])
@@ -170,6 +172,9 @@ class DataProcessor():
         photometry = {}
 
         data = ascii.read(data_product.data.path)
+        if len(data) < 1:
+            raise InvalidFileFormatException('Empty table or invalid file type')
+
         for datum in data:
             time = Time(float(datum['time']), format='mjd')
             utc = TimezoneInfo(utc_offset=0*units.hour)

--- a/tom_dataproducts/data_processor.py
+++ b/tom_dataproducts/data_processor.py
@@ -38,6 +38,7 @@ class DataProcessor():
 
         mimetype = mimetypes.guess_type(data_product.data.path)[0]
         print(mimetype)
+        print(mimetypes.knownfiles)
         if mimetype in FITS_MIMETYPES:
             return self._process_spectrum_from_fits(data_product)
         elif mimetype in PLAINTEXT_MIMETYPES:

--- a/tom_dataproducts/data_processor.py
+++ b/tom_dataproducts/data_processor.py
@@ -62,7 +62,6 @@ class DataProcessor():
         :rtype: AstroPy.Time
         """
 
-        # TODO: Add methods to Gemini, SOAR
         flux, header = fits.getdata(data_product.data.path, header=True)
 
         for facility_class in get_service_classes():

--- a/tom_dataproducts/data_processor.py
+++ b/tom_dataproducts/data_processor.py
@@ -17,6 +17,11 @@ PLAINTEXT_MIMETYPES = ['text/plain', 'text/csv']
 DEFAULT_WAVELENGTH_UNITS = units.angstrom
 DEFAULT_FLUX_CONSTANT = units.erg / units.cm ** 2 / units.second / units.angstrom
 
+mimetypes.add_type('image/fits', '.fits')
+mimetypes.add_type('image/fits', '.fz')
+mimetypes.add_type('application/fits', '.fits')
+mimetypes.add_type('application/fits', '.fz')
+
 
 class DataProcessor():
 

--- a/tom_dataproducts/forms.py
+++ b/tom_dataproducts/forms.py
@@ -1,9 +1,8 @@
 from django import forms
 
-from .models import DataProductGroup, DataProduct, PHOTOMETRY, SPECTROSCOPY
+from .models import DataProductGroup, DataProduct
 from tom_targets.models import Target
 from tom_observations.models import ObservationRecord
-from tom_observations.facility import get_service_classes
 
 
 class AddProductToGroupForm(forms.Form):
@@ -32,63 +31,9 @@ class DataProductUploadForm(forms.Form):
     )
     tag = forms.ChoiceField(
         choices=DataProduct.DATA_PRODUCT_TYPES,
-        widget=forms.HiddenInput(),
+        widget=forms.RadioSelect(),
         required=True
     )
     referrer = forms.CharField(
         widget=forms.HiddenInput()
-    )
-
-    def __init__(self, *args, **kwargs):
-        hide_target_fields = kwargs.pop('hide_target_fields', False)
-        super(DataProductUploadForm, self).__init__(*args, **kwargs)
-        if hide_target_fields:
-            self.fields['facility'].widget = forms.HiddenInput()
-
-    # def clean(self):
-    #     cleaned_data = super().clean()
-
-    #     # For dataproducts uploaded to target detail pages, facility and observation timestamp are only valid for
-    #     # spectroscopy. Bulk photometry uploads already have timestamp information per datum, and facility
-    #     # information can vary by datum.
-    #     # For dataproducts uploaded to observation pages, facility is taken from the observing record. Timestamp is
-    #     # simply ignored for photometry submissions--however, this should be improved upon in the future.
-    #     if cleaned_data.get('tag', '') == PHOTOMETRY[0]:
-    #         if cleaned_data.get('observation_timestamp'):
-    #             if not cleaned_data.get('observation_record'):
-    #                 raise forms.ValidationError('Observation timestamp is not valid for uploaded photometry')
-    #         if cleaned_data.get('facility'):
-    #             if not cleaned_data.get('observation_record'):
-    #                 raise forms.ValidationError('Facility is not valid for uploaded photometry.')
-    #     elif cleaned_data.get('tag', '') == SPECTROSCOPY[0]:
-    #         if not cleaned_data.get('observation_timestamp'):
-    #             raise forms.ValidationError('Observation timestamp is required for spectroscopy.')
-    #         if not cleaned_data.get('facility'):
-    #             if not cleaned_data.get('observation_record'):
-    #                 raise forms.ValidationError('Facility is required for spectroscopy.')
-    #             else:
-    #                 cleaned_data['facility'] = cleaned_data.get('observation_record').facility
-
-    #     return cleaned_data
-
-
-class PhotometryUploadForm(DataProductUploadForm):
-    pass
-
-
-class SpectroscopyUploadForm(DataProductUploadForm):
-    facility = forms.ChoiceField(
-        choices=[('', '----')] + [(k, k) for k in get_service_classes().keys()] + [('No processing', 'No processing')],
-        required=True,
-        help_text='Facility algorithm used to process the data - spectroscopy only'
-    )
-    observation_timestamp = forms.SplitDateTimeField(
-        label='Observation Time',
-        widget=forms.SplitDateTimeWidget(
-            date_attrs={'placeholder': 'Observation Date', 'type': 'date'},
-            time_attrs={'format': '%H:%M:%S', 'placeholder': 'Observation Time',
-                        'type': 'time', 'step': '1'}
-        ),
-        required=True,
-        help_text='Timestamp of the observation during which data was collected - spectroscopy only'
     )

--- a/tom_dataproducts/forms.py
+++ b/tom_dataproducts/forms.py
@@ -30,21 +30,10 @@ class DataProductUploadForm(forms.Form):
             attrs={'multiple': True}
         )
     )
-    tag = forms.ChoiceField(choices=DataProduct.DATA_PRODUCT_TYPES)
-    facility = forms.ChoiceField(
-        choices=[('', '----')] + [(k, k) for k in get_service_classes().keys()] + [('No processing', 'No processing')],
-        required=False,
-        help_text='Facility algorithm used to process the data - spectroscopy only'
-    )
-    observation_timestamp = forms.SplitDateTimeField(
-        label='Observation Time',
-        widget=forms.SplitDateTimeWidget(
-            date_attrs={'placeholder': 'Observation Date', 'type': 'date'},
-            time_attrs={'format': '%H:%M:%S', 'placeholder': 'Observation Time',
-                        'type': 'time', 'step': '1'}
-        ),
-        required=False,
-        help_text='Timestamp of the observation during which data was collected - spectroscopy only'
+    tag = forms.ChoiceField(
+        choices=DataProduct.DATA_PRODUCT_TYPES,
+        widget=forms.HiddenInput(),
+        required=True
     )
     referrer = forms.CharField(
         widget=forms.HiddenInput()
@@ -56,28 +45,50 @@ class DataProductUploadForm(forms.Form):
         if hide_target_fields:
             self.fields['facility'].widget = forms.HiddenInput()
 
-    def clean(self):
-        cleaned_data = super().clean()
+    # def clean(self):
+    #     cleaned_data = super().clean()
 
-        # For dataproducts uploaded to target detail pages, facility and observation timestamp are only valid for
-        # spectroscopy. Bulk photometry uploads already have timestamp information per datum, and facility
-        # information can vary by datum.
-        # For dataproducts uploaded to observation pages, facility is taken from the observing record. Timestamp is
-        # simply ignored for photometry submissions--however, this should be improved upon in the future.
-        if cleaned_data.get('tag', '') == PHOTOMETRY[0]:
-            if cleaned_data.get('observation_timestamp'):
-                if not cleaned_data.get('observation_record'):
-                    raise forms.ValidationError('Observation timestamp is not valid for uploaded photometry')
-            if cleaned_data.get('facility'):
-                if not cleaned_data.get('observation_record'):
-                    raise forms.ValidationError('Facility is not valid for uploaded photometry.')
-        elif cleaned_data.get('tag', '') == SPECTROSCOPY[0]:
-            if not cleaned_data.get('observation_timestamp'):
-                raise forms.ValidationError('Observation timestamp is required for spectroscopy.')
-            if not cleaned_data.get('facility'):
-                if not cleaned_data.get('observation_record'):
-                    raise forms.ValidationError('Facility is required for spectroscopy.')
-                else:
-                    cleaned_data['facility'] = cleaned_data.get('observation_record').facility
+    #     # For dataproducts uploaded to target detail pages, facility and observation timestamp are only valid for
+    #     # spectroscopy. Bulk photometry uploads already have timestamp information per datum, and facility
+    #     # information can vary by datum.
+    #     # For dataproducts uploaded to observation pages, facility is taken from the observing record. Timestamp is
+    #     # simply ignored for photometry submissions--however, this should be improved upon in the future.
+    #     if cleaned_data.get('tag', '') == PHOTOMETRY[0]:
+    #         if cleaned_data.get('observation_timestamp'):
+    #             if not cleaned_data.get('observation_record'):
+    #                 raise forms.ValidationError('Observation timestamp is not valid for uploaded photometry')
+    #         if cleaned_data.get('facility'):
+    #             if not cleaned_data.get('observation_record'):
+    #                 raise forms.ValidationError('Facility is not valid for uploaded photometry.')
+    #     elif cleaned_data.get('tag', '') == SPECTROSCOPY[0]:
+    #         if not cleaned_data.get('observation_timestamp'):
+    #             raise forms.ValidationError('Observation timestamp is required for spectroscopy.')
+    #         if not cleaned_data.get('facility'):
+    #             if not cleaned_data.get('observation_record'):
+    #                 raise forms.ValidationError('Facility is required for spectroscopy.')
+    #             else:
+    #                 cleaned_data['facility'] = cleaned_data.get('observation_record').facility
 
-        return cleaned_data
+    #     return cleaned_data
+
+
+class PhotometryUploadForm(DataProductUploadForm):
+    pass
+
+
+class SpectroscopyUploadForm(DataProductUploadForm):
+    facility = forms.ChoiceField(
+        choices=[('', '----')] + [(k, k) for k in get_service_classes().keys()] + [('No processing', 'No processing')],
+        required=True,
+        help_text='Facility algorithm used to process the data - spectroscopy only'
+    )
+    observation_timestamp = forms.SplitDateTimeField(
+        label='Observation Time',
+        widget=forms.SplitDateTimeWidget(
+            date_attrs={'placeholder': 'Observation Date', 'type': 'date'},
+            time_attrs={'format': '%H:%M:%S', 'placeholder': 'Observation Time',
+                        'type': 'time', 'step': '1'}
+        ),
+        required=True,
+        help_text='Timestamp of the observation during which data was collected - spectroscopy only'
+    )

--- a/tom_dataproducts/hooks.py
+++ b/tom_dataproducts/hooks.py
@@ -9,7 +9,7 @@ from .models import ReducedDatum, SPECTROSCOPY, PHOTOMETRY
 DEFAULT_DATA_PROCESSOR_CLASS = 'tom_dataproducts.data_processor.DataProcessor'
 
 
-def data_product_post_upload(dp, observation_timestamp, facility):
+def data_product_post_upload(dp):
     try:
         processor_class = settings.DATA_PROCESSOR_CLASS
     except Exception:
@@ -24,13 +24,13 @@ def data_product_post_upload(dp, observation_timestamp, facility):
     data_processor = clazz()
 
     if dp.tag == SPECTROSCOPY[0]:
-        spectrum = data_processor.process_spectroscopy(dp, facility)
+        spectrum, obs_date = data_processor.process_spectroscopy(dp)
         serialized_spectrum = SpectrumSerializer().serialize(spectrum)
         ReducedDatum.objects.create(
             target=dp.target,
             data_product=dp,
             data_type=dp.tag,
-            timestamp=observation_timestamp,
+            timestamp=obs_date,
             value=serialized_spectrum
         )
     elif dp.tag == PHOTOMETRY[0]:

--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 import os
 import tempfile
-import magic
 
 from astropy.io import fits
 from django.conf import settings

--- a/tom_dataproducts/tests/tests.py
+++ b/tom_dataproducts/tests/tests.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+import mimetypes
 
 from django.test import TestCase, override_settings
 from django.contrib.auth.models import User
@@ -281,6 +282,10 @@ class TestDataProcessor(TestCase):
         )
         self.data_processor = DataProcessor()
         self.test_file = SimpleUploadedFile('afile.fits', b'somedata')
+        mimetypes.add_type('image/fits', '.fits')
+        mimetypes.add_type('image/fits', '.fz')
+        mimetypes.add_type('application/fits', '.fits')
+        mimetypes.add_type('application/fits', '.fz')
 
     @patch('tom_dataproducts.data_processor.DataProcessor._process_spectrum_from_fits')
     def test_process_spectroscopy_with_fits_file(self, process_data_mock):

--- a/tom_dataproducts/tests/tests.py
+++ b/tom_dataproducts/tests/tests.py
@@ -294,8 +294,7 @@ class TestDataProcessor(TestCase):
         self.data_processor.process_spectroscopy(self.data_product)
         process_data_mock.assert_called_with(self.data_product)
 
-    @patch('tom_dataproducts.data_processor.mimetypes.guess_type')
-    def test_process_spectroscopy_with_invalid_file_type(self, mimetypes_mock):
+    def test_process_spectroscopy_with_invalid_file_type(self):
         self.data_product.data.save('spectrum.png', self.test_file)
         with self.assertRaises(InvalidFileFormatException):
             self.data_processor.process_spectroscopy(self.data_product)

--- a/tom_dataproducts/tests/tests.py
+++ b/tom_dataproducts/tests/tests.py
@@ -1,7 +1,6 @@
 import json
 import os
 import tempfile
-import mimetypes
 
 from django.test import TestCase, override_settings
 from django.contrib.auth.models import User
@@ -282,10 +281,6 @@ class TestDataProcessor(TestCase):
         )
         self.data_processor = DataProcessor()
         self.test_file = SimpleUploadedFile('afile.fits', b'somedata')
-        mimetypes.add_type('image/fits', '.fits')
-        mimetypes.add_type('image/fits', '.fz')
-        mimetypes.add_type('application/fits', '.fits')
-        mimetypes.add_type('application/fits', '.fz')
 
     @patch('tom_dataproducts.data_processor.DataProcessor._process_spectrum_from_fits')
     def test_process_spectroscopy_with_fits_file(self, process_data_mock):

--- a/tom_dataproducts/views.py
+++ b/tom_dataproducts/views.py
@@ -78,7 +78,7 @@ class DataProductUploadView(LoginRequiredMixin, FormView):
             )
             dp.save()
             try:
-                run_hook('data_product_post_upload', dp, observation_timestamp, facility)
+                run_hook('data_product_post_upload', dp)
                 successful_uploads.append(str(dp))
             except InvalidFileFormatException:
                 ReducedDatum.objects.filter(data_product=dp).delete()

--- a/tom_dataproducts/views.py
+++ b/tom_dataproducts/views.py
@@ -58,8 +58,6 @@ class DataProductUploadView(LoginRequiredMixin, FormView):
 
     def form_valid(self, form):
         target = form.cleaned_data['target']
-        observation_timestamp = form.cleaned_data.get('observation_timestamp', None)
-        facility = form.cleaned_data.get('facility', None)
         if not target:
             observation_record = form.cleaned_data['observation_record']
             target = observation_record.target

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -383,6 +383,16 @@ class LCOFacility(GenericObservationFacility):
         return header.get(FITS_FACILITY_DATE_OBS_KEYWORD, None)
 
     def is_fits_facility(self, header):
+        """
+        Returns True if the 'ORIGIN' keyword is in the given FITS header and contains the value 'LCOGT', False
+        otherwise.
+
+        :param header: FITS header object
+        :type header: dictionary-like
+
+        :returns: True if header matches LCOGT, False otherwise
+        :rtype: boolean
+        """
         return FITS_FACILITY_KEYWORD_VALUE == header.get(FITS_FACILITY_KEYWORD, None)
 
     def get_terminal_observing_states(self):

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -28,6 +28,11 @@ TERMINAL_OBSERVING_STATES = ['COMPLETED', 'CANCELED', 'WINDOW_EXPIRED']
 FLUX_CONSTANT = (1e-15 * u.erg) / (u.cm ** 2 * u.second * u.angstrom)
 WAVELENGTH_UNITS = u.angstrom
 
+# FITS header keywords used for data processing
+FITS_FACILITY_KEYWORD = 'ORIGIN'
+FITS_FACILITY_KEYWORD_VALUE = 'LCOGT'
+FITS_FACILITY_DATE_OBS_KEYWORD = 'DATE-OBS'
+
 # Functions needed specifically for LCO
 
 
@@ -373,6 +378,12 @@ class LCOFacility(GenericObservationFacility):
 
     def get_wavelength_units(self):
         return WAVELENGTH_UNITS
+
+    def get_date_obs_from_fits_header(self, header):
+        return header.get(FITS_FACILITY_DATE_OBS_KEYWORD, None)
+
+    def is_fits_facility(self, header):
+        return FITS_FACILITY_KEYWORD_VALUE == header.get(FITS_FACILITY_KEYWORD, None)
 
     def get_terminal_observing_states(self):
         return TERMINAL_OBSERVING_STATES

--- a/tom_observations/facility.py
+++ b/tom_observations/facility.py
@@ -182,6 +182,9 @@ class GenericObservationFacility(ABC):
         """
         pass
 
+    def is_fits_facility(self, header):
+        return False
+
     @abstractmethod
     def get_terminal_observing_states(self):
         """

--- a/tom_observations/facility.py
+++ b/tom_observations/facility.py
@@ -183,6 +183,10 @@ class GenericObservationFacility(ABC):
         pass
 
     def is_fits_facility(self, header):
+        """
+        Returns True if the FITS header is from this facility based on valid keywords and associated
+        values, False otherwise.
+        """
         return False
 
     @abstractmethod

--- a/tom_observations/views.py
+++ b/tom_observations/views.py
@@ -73,6 +73,7 @@ class ObservationCreateView(LoginRequiredMixin, FormView):
 
     def get_observation_type(self):
         if self.request.method == 'GET':
+            # TODO: This appears to not work as intended.
             return self.request.GET.get('observation_type', self.get_facility_class().observation_types[0])
         elif self.request.method == 'POST':
             return self.request.POST.get('observation_type')
@@ -175,16 +176,11 @@ class ObservationRecordDetailView(DetailView):
                 data_product.get_file_extension() == '.fits' else newest_image
         if newest_image:
             context['image'] = newest_image.get_image_data()
-        data_timestamp = self.get_object().scheduled_end if self.get_object().scheduled_end \
-            else self.get_object().created
         data_product_upload_form = DataProductUploadForm(
             initial={
                 'observation_record': self.get_object(),
-                'observation_timestamp': data_timestamp,
-                'facility': self.get_object().facility,
                 'referrer': reverse('tom_observations:detail', args=(self.get_object().id,))
-            },
-            hide_target_fields=True
+            }
         )
         context['data_product_form'] = data_product_upload_form
         return context

--- a/tom_setup/management/commands/tom_setup.py
+++ b/tom_setup/management/commands/tom_setup.py
@@ -144,12 +144,6 @@ class Command(BaseCommand):
         group.save()
         self.ok()
 
-    def add_fits_mimetypes(self):
-        mimetypes.add_type('image/fits', '.fits')
-        mimetypes.add_type('image/fits', '.fz')
-        mimetypes.add_type('application/fits', '.fits')
-        mimetypes.add_type('application/fits', '.fz')
-
     def complete(self):
         self.exit(
             self.style.SUCCESS('Setup complete! Run ./manage.py migrate && ./manage.py runserver to start your TOM.')
@@ -168,5 +162,4 @@ class Command(BaseCommand):
         self.run_migrations()
         self.create_pi()
         self.create_public_group()
-        self.add_fits_mimetypes()
         self.complete()

--- a/tom_setup/management/commands/tom_setup.py
+++ b/tom_setup/management/commands/tom_setup.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand
 import sys
 import os
+import mimetypes
 from django.conf import settings
 from django.template.loader import get_template
 from django.core.management import call_command
@@ -143,6 +144,12 @@ class Command(BaseCommand):
         group.save()
         self.ok()
 
+    def add_fits_mimetypes(self):
+        mimetypes.add_type('image/fits', '.fits')
+        mimetypes.add_type('image/fits', '.fz')
+        mimetypes.add_type('application/fits', '.fits')
+        mimetypes.add_type('application/fits', '.fz')
+
     def complete(self):
         self.exit(
             self.style.SUCCESS('Setup complete! Run ./manage.py migrate && ./manage.py runserver to start your TOM.')
@@ -161,4 +168,5 @@ class Command(BaseCommand):
         self.run_migrations()
         self.create_pi()
         self.create_public_group()
+        self.add_fits_mimetypes()
         self.complete()

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -1,13 +1,14 @@
-from django.test import TestCase, override_settings
-from django.urls import reverse
-from django.contrib.auth.models import User, Group
 import pytz
 import ephem
-from astropy import units
-from astropy.coordinates import Angle
 import math
 from unittest import mock
 from datetime import datetime, timedelta
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.contrib.auth.models import User, Group
+from astropy import units
+from astropy.coordinates import Angle
 
 from .factories import SiderealTargetFactory, NonSiderealTargetFactory, TargetGroupingFactory
 from tom_targets.models import Target, TargetExtra, TargetList

--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -158,8 +158,7 @@ class TargetDetailView(PermissionRequiredMixin, DetailView):
             initial={
                 'target': self.get_object(),
                 'referrer': reverse('tom_targets:detail', args=(self.get_object().id,))
-            },
-            hide_target_fields=False
+            }
         )
         context['data_product_form'] = data_product_upload_form
         return context


### PR DESCRIPTION
This PR addresses the following:

- Removes libmagic dependency, replaces with mimetypes
- Reads facility and date-obs from fits headers or CSV comments as applicable
- Drastically simplifies data product upload form
- Reorders tom_targets.tests dependencies for some reason