### PR TITLE
Consolidated target creation

### DIFF
--- a/tom_common/tests.py
+++ b/tom_common/tests.py
@@ -98,4 +98,4 @@ class TestAuthScheme(TestCase):
     def test_user_can_access_view(self):
         response = self.client.get(reverse('tom_targets:list'))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Add a target')
+        self.assertContains(response, 'Create Targets')

--- a/tom_targets/templates/tom_targets/target_form.html
+++ b/tom_targets/templates/tom_targets/target_form.html
@@ -3,7 +3,6 @@
 {% block title %}New target{% endblock %}
 {% block content %}
 {% if not object %}
-<a href="{% url 'tom_catalogs:query' %}" class="btn btn-primary float-right">Search online sources</a>
 <ul class="nav nav-tabs">
   {% for k, v in type_choices %}
     <li class="nav-item">

--- a/tom_targets/templates/tom_targets/target_list.html
+++ b/tom_targets/templates/tom_targets/target_list.html
@@ -8,9 +8,15 @@
       <div class="col-md-12">
         <span class="float-right">
         {{ target_count }} Targets &nbsp;
+        <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Create Targets
+        </button>
+        <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+          <a class="dropdown-item" href="{% url 'targets:create' %}" title="Create a Target">Create a Target</a>
+          <a class="dropdown-item" href="{% url 'targets:import' %}" title="Import Targets">Import Targets</a>
+          <a class="dropdown-item" href="{% url 'tom_catalogs:query' %}" title="Catalog Search">Catalog Search</a>
+        </div>
         <a href="{% url 'dataproducts:update-reduced-data' %}" class="btn btn-primary" title="Update Targets">Update Targets</a>
-        <a href="{% url 'targets:create' %}" class="btn btn-primary" title="Add Target">Add a target</a>
-        <a href="{% url 'targets:import' %}" class="btn btn-primary" title="Import Targets">Import Targets</a>
         <button onclick="document.getElementById('invisible-export-button').click()" class="btn btn-primary">Export Filtered Targets</button>
          <!-- use an invisible button, because the key "Enter" event will triggered the first submit button and we want the default action to be applying filter -->
       </span>


### PR DESCRIPTION
Very quickly addressing Andy's concern about ambiguity in target creation. This consolidates the three methods of target creation (manual, import, and catalog search) into one button/dropdown.