### PR TITLE
Quick fixes so main target table displays correctly

### DIFF
--- a/tom_targets/filters.py
+++ b/tom_targets/filters.py
@@ -54,7 +54,7 @@ class TargetFilter(django_filters.FilterSet):
     name = django_filters.CharFilter(method='filter_name', label='Name')
 
     def filter_name(self, queryset, name, value):
-        return queryset.filter(Q(name__icontains=value) | Q(aliases__name__icontains=value))
+        return queryset.filter(Q(name__icontains=value) | Q(aliases__name__icontains=value)).distinct()
 
     # hide target grouping list if user not logged in
     def get_target_list_queryset(request):

--- a/tom_targets/templates/tom_targets/target_list.html
+++ b/tom_targets/templates/tom_targets/target_list.html
@@ -62,7 +62,6 @@
             <td>
                 <a href="{% url 'targets:detail' target.id %}" title="{{ target.name }}">{{ target.names|join:", " }}</a>
             </td>
-            <td>{{ target.name }}</td>
             <td>{{ target.get_type_display }}</td>
             {% if request.GET.type == 'SIDEREAL' %}
             <td>{{ target.ra }}</td>


### PR DESCRIPTION
Fixes two small problems I noticed after updating SNEx 2 to tomtoolkit 1.0:
If a search string is in multiple names for a single target (e.g. '17cbv' is in both 'AT 2017cbv' and 'SN 2017cbv'), searching would return the same target multiple times.
Removed duplicated column in targets table.