### PR TITLE
Install dataclasses if python < 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'pillow',
         'fits2image',
         'specutils',
+        "dataclasses; python_version < '3.7'",
     ],
     extras_require={
         'test': ['factory_boy']


### PR DESCRIPTION
Should fix #13