### PR TITLE
More options on data upload form

### DIFF
--- a/tom_dataproducts/forms.py
+++ b/tom_dataproducts/forms.py
@@ -1,8 +1,13 @@
 from django import forms
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout, Div, Fieldset
 
 from .models import DataProductGroup, DataProduct
 from tom_targets.models import Target
 from tom_observations.models import ObservationRecord
+
+from astropy.io.ascii.core import FORMAT_CLASSES
+from astropy.time import TIME_FORMATS
 
 
 class AddProductToGroupForm(forms.Form):
@@ -34,6 +39,67 @@ class DataProductUploadForm(forms.Form):
         widget=forms.RadioSelect(),
         required=True
     )
+    photometry_format = forms.TypedChoiceField(
+        choices=((None, 'guess'),) + tuple((fmt, fmt.replace('_', ' ')) for fmt in FORMAT_CLASSES),
+        empty_value=None,
+        required=False,
+        help_text='See documentation for '
+                  '<a href="https://astropy.readthedocs.io/en/stable/io/ascii/index.html#supported-formats">'
+                  'astropy.io.ascii.read</a>. '
+    )
+    time_format = forms.ChoiceField(
+        choices=tuple((fmt, fmt.replace('_', ' ')) for fmt in TIME_FORMATS if 'datetime' not in fmt),
+        initial='mjd',
+        required=False,
+        help_text='See documentation for '
+                  '<a href="https://astropy.readthedocs.io/en/stable/time/index.html#time-format">'
+                  'astropy.time.Time</a>.'
+    )
+    time_column = forms.CharField(
+        widget=forms.TextInput(attrs={'value': 'time'}),
+        required=False
+    )
+    magnitude_column = forms.CharField(
+        widget=forms.TextInput(attrs={'value': 'magnitude'}),
+        required=False
+    )
+    error_column = forms.CharField(
+        widget=forms.TextInput(attrs={'value': 'error'}),
+        required=False
+    )
+    filter_column = forms.CharField(
+        widget=forms.TextInput(attrs={'value': 'filter'}),
+        required=False
+    )
     referrer = forms.CharField(
         widget=forms.HiddenInput()
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            Div(
+                'files',
+                'tag',
+                css_class='form-row',
+            ),
+            Fieldset(
+                'Photometry',
+                Div(
+                    Div(
+                        'photometry_format',
+                        'magnitude_column',
+                        'error_column',
+                        css_class='col',
+                    ),
+                    Div(
+                        'time_format',
+                        'time_column',
+                        'filter_column',
+                        css_class='col',
+                    ),
+                    css_class='form-row',
+                )
+            )
+        )

--- a/tom_dataproducts/forms.py
+++ b/tom_dataproducts/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout, Div, Fieldset
+from crispy_forms.layout import Layout, Div, Fieldset, Submit
 
 from .models import DataProductGroup, DataProduct
 from tom_targets.models import Target
@@ -39,13 +39,13 @@ class DataProductUploadForm(forms.Form):
         widget=forms.RadioSelect(),
         required=True
     )
-    photometry_format = forms.TypedChoiceField(
+    table_format = forms.TypedChoiceField(
         choices=((None, 'guess'),) + tuple((fmt, fmt.replace('_', ' ')) for fmt in FORMAT_CLASSES),
         empty_value=None,
         required=False,
         help_text='See documentation for '
                   '<a href="https://astropy.readthedocs.io/en/stable/io/ascii/index.html#supported-formats">'
-                  'astropy.io.ascii.read</a>. '
+                  'astropy.io.ascii.read</a>.'
     )
     time_format = forms.ChoiceField(
         choices=tuple((fmt, fmt.replace('_', ' ')) for fmt in TIME_FORMATS if 'datetime' not in fmt),
@@ -55,9 +55,10 @@ class DataProductUploadForm(forms.Form):
                   '<a href="https://astropy.readthedocs.io/en/stable/time/index.html#time-format">'
                   'astropy.time.Time</a>.'
     )
-    time_column = forms.CharField(
-        widget=forms.TextInput(attrs={'value': 'time'}),
-        required=False
+    time_keyword = forms.CharField(
+        widget=forms.TextInput(attrs={'value': 'MJD'}),
+        required=False,
+        help_text='Column header for photometry, header keyword for spectra.'
     )
     magnitude_column = forms.CharField(
         widget=forms.TextInput(attrs={'value': 'magnitude'}),
@@ -71,6 +72,18 @@ class DataProductUploadForm(forms.Form):
         widget=forms.TextInput(attrs={'value': 'filter'}),
         required=False
     )
+    time = forms.DateTimeField(
+        required=False,
+        help_text='Overrides header keyword.'
+    )
+    wavelength_column = forms.CharField(
+        widget=forms.TextInput(attrs={'value': 'col1'}),
+        required=False
+    )
+    flux_column = forms.CharField(
+        widget=forms.TextInput(attrs={'value': 'col2'}),
+        required=False
+    )
     referrer = forms.CharField(
         widget=forms.HiddenInput()
     )
@@ -78,28 +91,38 @@ class DataProductUploadForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
+        self.helper.add_input(Submit('submit', 'Upload'))
         self.helper.layout = Layout(
+            'observation_record',
+            'target',
             Div(
-                'files',
-                'tag',
+                Div('files', css_class='col'),
+                Div('tag', css_class='col'),
                 css_class='form-row',
+            ),
+            Div(
+                Div('table_format', css_class='col'),
+                Div('time_format', css_class='col'),
+                Div('time_keyword', css_class='col'),
+                css_class='form-row'
             ),
             Fieldset(
                 'Photometry',
                 Div(
-                    Div(
-                        'photometry_format',
-                        'magnitude_column',
-                        'error_column',
-                        css_class='col',
-                    ),
-                    Div(
-                        'time_format',
-                        'time_column',
-                        'filter_column',
-                        css_class='col',
-                    ),
-                    css_class='form-row',
+                    Div('magnitude_column', css_class='col'),
+                    Div('error_column', css_class='col'),
+                    Div('filter_column', css_class='col'),
+                    css_class='form-row'
                 )
-            )
+            ),
+            Fieldset(
+                'Spectroscopy',
+                Div(
+                    Div('time', css_class='col'),
+                    Div('wavelength_column', css_class='col'),
+                    Div('flux_column', css_class='col'),
+                    css_class='form-row'
+                )
+            ),
+            'referrer'
         )

--- a/tom_dataproducts/templates/tom_dataproducts/upload_dataproduct.html
+++ b/tom_dataproducts/templates/tom_dataproducts/upload_dataproduct.html
@@ -1,9 +1,9 @@
-{% load bootstrap4 %}
+{% load bootstrap4 crispy_forms_tags %}
 {% if user.is_authenticated %}
 <h4>Upload a data product</h4>
 <form method="POST" action="{% url 'tom_dataproducts:upload' %}" enctype="multipart/form-data">
   {% csrf_token %}
-  {% bootstrap_form data_product_form %}
+  {% crispy data_product_form %}
   {% buttons %}
   <input type="submit" class="btn btn-primary" value="Upload" name="upload_dataproduct_form">
   {% endbuttons %}

--- a/tom_dataproducts/templates/tom_dataproducts/upload_dataproduct.html
+++ b/tom_dataproducts/templates/tom_dataproducts/upload_dataproduct.html
@@ -4,8 +4,5 @@
 <form method="POST" action="{% url 'tom_dataproducts:upload' %}" enctype="multipart/form-data">
   {% csrf_token %}
   {% crispy data_product_form %}
-  {% buttons %}
-  <input type="submit" class="btn btn-primary" value="Upload" name="upload_dataproduct_form">
-  {% endbuttons %}
 </form>
 {% endif %}

--- a/tom_dataproducts/views.py
+++ b/tom_dataproducts/views.py
@@ -86,7 +86,7 @@ class DataProductUploadView(LoginRequiredMixin, FormView):
             dp.save()
             try:
                 run_hook('data_product_post_upload', dp)
-                run_data_processor(dp)
+                run_data_processor(dp, form.cleaned_data)
                 successful_uploads.append(str(dp))
             except InvalidFileFormatException:
                 ReducedDatum.objects.filter(data_product=dp).delete()

--- a/tom_dataproducts/views.py
+++ b/tom_dataproducts/views.py
@@ -29,6 +29,10 @@ from tom_observations.facility import get_service_class
 from tom_common.hooks import run_hook
 from tom_common.hints import add_hint
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class DataProductSaveView(LoginRequiredMixin, View):
     def post(self, request, *args, **kwargs):
@@ -91,9 +95,10 @@ class DataProductUploadView(LoginRequiredMixin, FormView):
                     self.request,
                     'There was a problem uploading your file--the file format was invalid for file: {0}'.format(str(dp))
                 )
-            except Exception:
+            except Exception as e:
                 ReducedDatum.objects.filter(data_product=dp).delete()
                 dp.delete()
+                logging.error(':'.join(e.args))
                 messages.error(self.request, 'There was a problem processing your file: {0}'.format(str(dp)))
         if successful_uploads:
             messages.success(


### PR DESCRIPTION
Uploading reduced data products currently requires that they be in a very specific format, which is not standard across different facilities. I added some more options to the data upload form that allows the user more flexibility in the file format. All these formats are already available in Astropy, so it was mostly a matter of piping them through to the form. This certainly doesn't cover all possible formats, but it's an improvement over having to reformat every file I want to upload to match the TOM Toolkit format.

All plain text files:
 - table format
 - time format
 - where to find the time (column header or header keyword)

Photometry:
 - column headers for magnitude, error, and filter

Spectroscopy:
 - manually input date-obs
 - column headers for wavelength and flux (for plain text files)

Ideally, it would be nice to dynamically update the form fields based on the type of data being uploaded (tag), but I don't know how to do this.

This may also make the "FITS facility" framework obsolete, but I left that alone in case it's needed for something else.