### PR TITLE
Adding marker at target position on Aladin map

### DIFF
--- a/tom_observations/tests/tests.py
+++ b/tom_observations/tests/tests.py
@@ -163,4 +163,4 @@ class TestGetVisibility(TestCase):
         ]
         self.assertEqual(len(airmass_data), len(expected_airmass))
         for i in range(0, len(expected_airmass)):
-            self.assertAlmostEqual(airmass_data[i], expected_airmass[i])
+            self.assertAlmostEqual(airmass_data[i], expected_airmass[i], places=3)

--- a/tom_targets/templates/tom_targets/partials/aladin.html
+++ b/tom_targets/templates/tom_targets/partials/aladin.html
@@ -11,4 +11,8 @@
       target: "{{ target.ra }} {{ target.dec }}",
       showGotoControl: false,
     });
+    var target_cat = A.catalog({name: '{{ target.name }}', sourceSize: 10, color: 'red'});
+    aladin.addCatalog(target_cat, {shape: 'circle'});
+    target_cat.addSources([A.marker({{ target.ra }}, {{ target.dec }}, 
+      {popupTitle: '{{ target.name }}'})]);
 </script>


### PR DESCRIPTION
Addresses [issue 198](https://github.com/TOMToolkit/tom_base/issues/198) by adding a marker at the target position on the Aladin maps that get generated for each target detail page. This lets users see where exactly the target is even if you pan around the map.