### PR TITLE
Minor fix so default observation form is active tab

### DIFF
--- a/tom_observations/templates/tom_observations/observation_form.html
+++ b/tom_observations/templates/tom_observations/observation_form.html
@@ -6,7 +6,7 @@
 <ul class="nav nav-tabs">
   {% for k, v in type_choices %}
     <li class="nav-item">
-      <a class="nav-link {% if request.GET.observation_type == k or observation_type not in request.GET and first %} active {% endif %}" href="{% url 'observations:create' facility=form.facility.value %}?target_id={{ form.target_id.value }}&observation_type={{ k }}">{{ v }}</a>
+      <a class="nav-link {% if request.GET.observation_type == k or 'observation_type' not in request.GET and forloop.first %} active {% endif %}" href="{% url 'observations:create' facility=form.facility.value %}?target_id={{ form.target_id.value }}&observation_type={{ k }}">{{ v }}</a>
     </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
Small fix to the observation form template. The template has multiple tabs (one for each observation type), and this correctly registers the default (first) tab as the active one. Just a minor aesthetic fix.

Tested on facilities with one and multiple observations types.