### PR TITLE
get earliest/latest ReducedDatum by timestamp

### DIFF
--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -331,6 +331,9 @@ class ReducedDatum(models.Model):
     timestamp = models.DateTimeField(null=False, blank=False, default=datetime.now, db_index=True)
     value = models.TextField(null=False, blank=False)
 
+    class Meta:
+        get_latest_by = ('timestamp',)
+
     def save(self, *args, **kwargs):
         for dp_type, dp_values in settings.DATA_PRODUCT_TYPES.items():
             if self.data_type and self.data_type == dp_values[0]:


### PR DESCRIPTION
This allows easy access to the latest photometry point or spectrum of a target on the command line by using `target.reduceddatum_set.latest`, which is useful, for example, for displaying how bright a target currently is. Currently, running this command raises `ValueError: earliest() and latest() require either fields as positional arguments or 'get_latest_by' in the model's Meta.`