### PR TITLE
Converted non-sidereal form to crispy_form in order to insert note ab…

### DIFF
--- a/tom_targets/forms.py
+++ b/tom_targets/forms.py
@@ -1,6 +1,8 @@
-from django import forms
 from astropy.coordinates import Angle
 from astropy import units as u
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Field, Fieldset, HTML, Layout
+from django import forms
 from django.forms import ValidationError, inlineformset_factory
 from django.conf import settings
 from django.contrib.auth.models import Group
@@ -118,6 +120,19 @@ class SiderealTargetCreateForm(TargetForm):
 class NonSiderealTargetCreateForm(TargetForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+        self.helper.form_style = 'inline'
+        fieldset = Fieldset(None)
+        fieldset.append(Field('name', placeholder='Name'))
+        fieldset.append(Field('type'))
+        fieldset.append(Field('scheme'))
+        fieldset.append(HTML('<small class=\"text-muted\">Note: coordinates are heliocentric.</small>'))
+        for field_name in NON_SIDEREAL_FIELDS:
+            if field_name not in ['name', 'type', 'scheme']:
+                fieldset.append(Field(field_name, placeholder=Target._meta.get_field(field_name).verbose_name))
+        self.helper.layout = Layout(fieldset)
+
         for field in REQUIRED_NON_SIDEREAL_FIELDS:
             self.fields[field].required = True
 

--- a/tom_targets/forms.py
+++ b/tom_targets/forms.py
@@ -124,13 +124,13 @@ class NonSiderealTargetCreateForm(TargetForm):
         self.helper = FormHelper()
         self.helper.form_style = 'inline'
         fieldset = Fieldset(None)
-        fieldset.append(Field('name', placeholder='Name'))
+        fieldset.append(Field('name'))
         fieldset.append(Field('type'))
         fieldset.append(Field('scheme'))
         fieldset.append(HTML('<small class=\"text-muted\">Note: coordinates are heliocentric.</small>'))
         for field_name in NON_SIDEREAL_FIELDS:
             if field_name not in ['name', 'type', 'scheme']:
-                fieldset.append(Field(field_name, placeholder=Target._meta.get_field(field_name).verbose_name))
+                fieldset.append(Field(field_name))
         self.helper.layout = Layout(fieldset)
 
         for field in REQUIRED_NON_SIDEREAL_FIELDS:

--- a/tom_targets/templates/tom_targets/partials/target_data.html
+++ b/tom_targets/templates/tom_targets/partials/target_data.html
@@ -11,9 +11,12 @@
     <dd class="col-sm-6">{{ target_name }}</dd>
   {% endfor %}
   {% for key, value in target.as_dict.items %}
+  {% if target.type == 'NON_SIDEREAL' and key == 'epoch_of_elements' %}
+    <small class="text-muted col-sm-12">Note: coordinates are heliocentric</small>
+  {% endif %}
   {% if value and key != 'name' %}
-  <dt class="col-sm-6">{% verbose_name target key %}</dt>
-  <dd class="col-sm-6">{{ value|truncate_number }}</dd>
+    <dt class="col-sm-6">{% verbose_name target key %}</dt>
+    <dd class="col-sm-6">{{ value|truncate_number }}</dd>
   {% endif %}
   {% if key == 'ra' %}
     <dt class="col-sm-6">&nbsp;</dt>

--- a/tom_targets/templates/tom_targets/target_form.html
+++ b/tom_targets/templates/tom_targets/target_form.html
@@ -1,5 +1,5 @@
 {% extends 'tom_common/base.html' %}
-{% load bootstrap4 %}
+{% load bootstrap4 crispy_forms_tags %}
 {% block title %}New Target{% endblock %}
 {% block content %}
 {% if not object %}
@@ -21,7 +21,7 @@
   <form method="post" class="form">
 {% endif %}
 {% csrf_token %}
-{% bootstrap_form form %}
+{% crispy form %}
 {% bootstrap_formset names_form %}
 <h3>Tags</h3>
 {% bootstrap_formset extra_form %}

--- a/tom_targets/templates/tom_targets/target_form.html
+++ b/tom_targets/templates/tom_targets/target_form.html
@@ -12,14 +12,9 @@
     {% endfor %}
 {% else %}
 <h3> Update {{ object.name }}</h3>
-
 {% endif %}
 </ul>
-{% if not object %}
-  <form method="post" class="form">
-{% else %}
-  <form method="post" class="form">
-{% endif %}
+<form method="post" class="form">
 {% csrf_token %}
 {% crispy form %}
 {% bootstrap_formset names_form %}


### PR DESCRIPTION
…out heliocentric coordinates

This is in response to #244 to explicitly note that coordinates should be stored in heliocentric. This will still require changes to labels elsewhere in the TOM Toolkit--however, @phycodurus I'm curious if you think we should just switch to crispy_forms for both Target types.

This PR may also eventually incorporate tools to convert to/from barycentric coordinates, but it's unclear if it's easily doable.