### PR TITLE
modify setup.py to allow support for Django 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,11 @@ setup(
     keywords=['tomtoolkit', 'astronomy', 'astrophysics', 'cosmology', 'science', 'fits', 'observatory'],
     packages=find_packages(),
     install_requires=[
-        'django<3.0',
+        'django>=2.2',  # TOM Toolkit requires db math functions
         'django-bootstrap4',
         'django-extensions',
         'django-filter',
-        'django-contrib-comments',
+        'django-contrib-comments>=1.9.2',  # Earlier version are incompatible with Django >= 3.0
         'django-gravatar2',
         'django-crispy-forms',
         'django-guardian',


### PR DESCRIPTION
When upgraded to Django 3 with django-contrib-comments < 1.9.2, the TOM Toolkit fails to start. To facilitate upgrading to Django 3, I've added a requirement of at least 1.9.2 for django-contrib-comments.

Additionally, Django 2.2 was identified as the minimum version due to the use of django.db.functions.math.