### PR TITLE
fix username in base navbar

### DIFF
--- a/tom_common/templates/tom_common/base.html
+++ b/tom_common/templates/tom_common/base.html
@@ -48,9 +48,9 @@
         {% if user.is_authenticated %}
           <li class="nav-item">
             {% if user.first_name or user.last_name %}
-            <a class="nav-link" href="{% url 'user-update' user.id %}">{{ user.first_name }} {{ user.last_name }}</a>
+            <a class="nav-link" href="{% url 'user-update' user.id %}">{{ user.first_name }} {{ user.last_name }} ({{ user.username }})</a>
             {% else %}
-            <a class="nav-link" href="{% url 'user-update' user.id %}">User {{ user.id }}</a>
+            <a class="nav-link" href="{% url 'user-update' user.id %}">{{ user.username }}</a>
             {% endif %}
           </li>
           <li>


### PR DESCRIPTION
Will be "First Last (username)" or "username" if no First Last.
(if either First _or_ Last are present they'll be shown with the
username in parens).

I'm 'PR'ing into development so you can manage when you want to pull this in.