### PR TITLE
Updated templatetag to display extras regardless of value

### DIFF
--- a/tom_targets/templates/tom_targets/partials/target_data.html
+++ b/tom_targets/templates/tom_targets/partials/target_data.html
@@ -26,11 +26,9 @@
   {% endfor %}
 </dl>
 <dl class="row">
-{% for key, value in target.extra_fields.items %}
-  {% if key in display_extras %}
-    <dt class="col-sm-6">{{ key }}</dt>
-    <dd class="col-sm-6">{{ value }}</dd>
-  {% endif %}
+{% for key, value in extras.items %}
+  <dt class="col-sm-6">{{ key }}</dt>
+  <dd class="col-sm-6">{{ value }}</dd>
 {% endfor %}
 </dl>
 <h4>Tags</h4>

--- a/tom_targets/templatetags/targets_extras.py
+++ b/tom_targets/templatetags/targets_extras.py
@@ -36,9 +36,10 @@ def target_data(target):
     """
     Displays the data of a target.
     """
+    extras = {k['name']: target.extra_fields.get(k['name'], '') for k in settings.EXTRA_FIELDS if not k.get('hidden')}
     return {
         'target': target,
-        'display_extras': [ex['name'] for ex in settings.EXTRA_FIELDS if not ex.get('hidden')]
+        'extras': extras
     }
 
 


### PR DESCRIPTION
Etienne pointed out in #240 that `TargetExtras` will not be displayed on `Targets` that don't have them. While this was originally by design, it seems like if a field is ubiquitous enough to be added to `settings.EXTRA_FIELDS`, it should probably appear on every target, value or not. The template can be overridden if this isn't desirable behavior.

I've discussed this with @rachel3834 and she concurs.