### PR TITLE
Feature/basic finder chart

### DIFF
--- a/tom_observations/facilities/lt.py
+++ b/tom_observations/facilities/lt.py
@@ -1,6 +1,6 @@
 from crispy_forms.layout import Layout, HTML
 
-from tom_observations.facility import GenericObservationForm
+from tom_observations.facility import GenericObservationFacility, GenericObservationForm
 
 
 class LTQueryForm(GenericObservationForm):
@@ -19,9 +19,30 @@ class LTQueryForm(GenericObservationForm):
         )
 
 
-class LTFacility():
+class LTFacility(GenericObservationFacility):
     name = 'LT'
     observation_types = [('Default', '')]
 
     def get_form(self, observation_type):
         return LTQueryForm
+
+    def submit_observation(self, observation_payload):
+        return
+
+    def validate_observation(self, observation_payload):
+        return
+
+    def get_observation_url(self, observation_id):
+        return
+
+    def get_terminal_observing_states(self):
+        return []
+
+    def get_observing_sites(self):
+        return {}
+
+    def get_observation_status(self, observation_id):
+        return
+
+    def data_products(self, observation_id, product_id=None):
+        return []

--- a/tom_observations/templates/tom_observations/observation_form.html
+++ b/tom_observations/templates/tom_observations/observation_form.html
@@ -1,8 +1,22 @@
 {% extends 'tom_common/base.html' %}
-{% load bootstrap4 crispy_forms_tags observation_extras %}
+{% load bootstrap4 crispy_forms_tags observation_extras targets_extras %}
 {% block title %}Submit Observation{% endblock %}
 {% block content %}
 <h3>Submit an observation to {{ form.facility.value }}</h3>
-{% observation_type_tabs %}
-{% crispy form %}
+{% if target.type == 'SIDEREAL' %}
+<div class="row">
+    <div class="col">
+    {% observation_plan target form.facility.value %}
+    </div>
+</div>
+{% endif %}
+<div class="row">
+    <div class="col-md-4">
+        {% target_data target %}
+    </div>
+    <div class="col-md-8">
+        {% observation_type_tabs %}
+        {% crispy form %}
+    </div>
+</div>
 {% endblock %}

--- a/tom_observations/templates/tom_observations/partials/observation_plan.html
+++ b/tom_observations/templates/tom_observations/partials/observation_plan.html
@@ -1,0 +1,4 @@
+{% load bootstrap4 %}
+<div id="plan-panel">
+  {{ visibility_graph|safe }}
+</div>

--- a/tom_observations/templatetags/observation_extras.py
+++ b/tom_observations/templatetags/observation_extras.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
 from django import forms, template
@@ -9,6 +10,7 @@ import plotly.graph_objs as go
 from tom_observations.models import ObservationRecord
 from tom_observations.facility import get_service_classes
 from tom_observations.observing_strategy import RunStrategyForm
+from tom_observations.utils import get_sidereal_visibility
 from tom_targets.models import Target
 
 
@@ -41,19 +43,38 @@ def observation_type_tabs(context):
     }
 
 
-@register.inclusion_tag('tom_observations/partials/observation_list.html', takes_context=True)
-def observation_list(context, target=None):
+@register.inclusion_tag('tom_observations/partials/observation_plan.html')
+def observation_plan(target, facility, length=7, interval=60, airmass_limit=None):
+    """
+    Displays form and renders plot for visibility calculation. Using this templatetag to render a plot requires that
+    the context of the parent view have values for start_time, end_time, and airmass.
+    """
+
+    visibility_graph = ''
+    start_time = datetime.now()
+    end_time = start_time + timedelta(days=length)
+
+    visibility_data = get_sidereal_visibility(target, start_time, end_time, interval, airmass_limit)
+    plot_data = [
+        go.Scatter(x=data[0], y=data[1], mode='lines', name=site) for site, data in visibility_data.items()
+    ]
+    layout = go.Layout(yaxis=dict(autorange='reversed'))
+    visibility_graph = offline.plot(
+        go.Figure(data=plot_data, layout=layout), output_type='div', show_link=False
+    )
+
+    return {
+        'visibility_graph': visibility_graph
+    }
+
+
+@register.inclusion_tag('tom_observations/partials/observation_list.html')
+def observation_list(target=None):
     """
     Displays a list of all observations in the TOM, limited to an individual target if specified.
     """
     if target:
-        if settings.TARGET_PERMISSIONS_ONLY:
-            observations = target.observationrecord_set.all()
-        else:
-            observations = get_objects_for_user(
-                                context['request'].user,
-                                'tom_observations.view_observationrecord'
-                            ).filter(target=target)
+        observations = target.observationrecord_set.all()
     else:
         observations = ObservationRecord.objects.all().order_by('-created')
     return {'observations': observations}

--- a/tom_observations/views.py
+++ b/tom_observations/views.py
@@ -174,6 +174,8 @@ class ObservationCreateView(LoginRequiredMixin, FormView):
         """
         context = super(ObservationCreateView, self).get_context_data(**kwargs)
         context['type_choices'] = self.get_facility_class().observation_types
+        target = Target.objects.get(pk=self.get_target_id())
+        context['target'] = target
         return context
 
     def get_form_class(self):

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -237,7 +237,7 @@ TOM_LATEX_PROCESSORS = {
 TOM_FACILITY_CLASSES = [
     'tom_observations.facilities.lco.LCOFacility',
     'tom_observations.facilities.gemini.GEMFacility',
-    'tom_observations.facilities.soar.SOARFacility
+    'tom_observations.facilities.soar.SOARFacility',
     'tom_observations.facilities.lt.LTFacility'
 ]
 

--- a/tom_targets/templates/tom_targets/partials/aladin.html
+++ b/tom_targets/templates/tom_targets/partials/aladin.html
@@ -50,8 +50,7 @@
       showReticle: false,
       target: "{{ target.ra }} {{ target.dec }}",
       showGotoControl: false,
-      showZoomControl: false,
-      allowFullZoomout: false
+      showZoomControl: false
     });
 
     aladin.on('positionChanged', function() {

--- a/tom_targets/templates/tom_targets/partials/aladin.html
+++ b/tom_targets/templates/tom_targets/partials/aladin.html
@@ -63,18 +63,21 @@
     });
 
     function getScaleBarFromForm() {
-      const size = $('#scale-bar-size').val() || '1';
-      const units = $('#scale-bar-units-select option:selected').val() || 'arcmin';
-      const label = size + ' ' + units;
-      const sizeAsDegrees = toDegrees(Number(size), units);
-      return {size: Number(size), units: units, label: label, sizeAsDegrees: sizeAsDegrees};
+      let size = Number($('#scale-bar-size').val());
+      if (size < 0) {
+        size = 0;
+      }
+      const units = $('#scale-bar-units-select option:selected').val();
+      const label = String(size) + ' ' + units;
+      const sizeAsDegrees = toDegrees(size, units);
+      return {size: size, units: units, label: label, sizeAsDegrees: sizeAsDegrees};
     }
 
     function getFovAsDegreesFromForm() {
       const fov = Number($('#fov').val());
       const units = $('#fov-units-select option:selected').val();
       let fovAsDegrees;
-      if (fov && units) {
+      if (fov >= 0) {
         fovAsDegrees = toDegrees(fov, units);
       }
       return fovAsDegrees;
@@ -134,7 +137,7 @@
 
     function updateFromForm(ra, dec) {
       const fov = getFovAsDegreesFromForm();
-      if (fov) {
+      if (fov !== undefined) {
         aladin.setFov(fov);
         annotateChart(ra, dec);
       }

--- a/tom_targets/templates/tom_targets/partials/aladin.html
+++ b/tom_targets/templates/tom_targets/partials/aladin.html
@@ -6,11 +6,11 @@
 <form id="chart-form">
   <div class="form-group row">
     <label for="fov">Field of view</label>
-    <input type="number" id="fov" name="fov" min="0" value="5">
+    <input type="number" id="fov" name="fov" min="0" value="10">
     <div class="form-check form-check-inline">
-      <input class="form-check-input" type="radio" id="deg-fov-units" name="fov-units" value="deg" checked>
+      <input class="form-check-input" type="radio" id="deg-fov-units" name="fov-units" value="deg">
       <label class="form-check-label" for="deg-fov-units">deg</label><br>
-      <input class="form-check-input" type="radio" id="arcmin-fov-units" name="fov-units" value="arcmin">
+      <input class="form-check-input" type="radio" id="arcmin-fov-units" name="fov-units" value="arcmin" checked>
       <label class="form-check-label" for="arcmin-fov-units">arcmin</label><br>
       <input class="form-check-input" type="radio" id="arcsec-fov-units" name="fov-units" value="arcsec">
       <label class="form-check-label" for="arcsec-fov-units">arcsec</label>
@@ -20,9 +20,9 @@
     <label for="scale-bar-size">Scale bar size:</label>
     <input type="number" id="scale-bar-size" name="scale-bar-size" min="0" value="1">
     <div class="form-check form-check-inline">
-      <input type="radio" id="deg-scale-bar-units" name="scale-bar-units" value="deg" checked>
+      <input type="radio" id="deg-scale-bar-units" name="scale-bar-units" value="deg">
       <label for="deg-scale-bar-units">deg</label><br>
-      <input type="radio" id="arcmin-scale-bar-units" name="scale-bar-units" value="arcmin">
+      <input type="radio" id="arcmin-scale-bar-units" name="scale-bar-units" value="arcmin" checked>
       <label for="arcmin-scale-bar-units">arcmin</label><br>
       <input type="radio" id="arcsec-scale-bar-units" name="scale-bar-units" value="arcsec">
       <label for="arcsec-scale-bar-units">arcsec</label>
@@ -38,7 +38,7 @@
 
     let aladin = A.aladin('#aladin-lite-div', {
       survey: "P/DSS2/color",
-      fov: getFovFromForm(),
+      fov: getFovAsDegreesFromForm(),
       showReticle: false,
       target: "{{ target.ra }} {{ target.dec }}",
       showGotoControl: false,
@@ -54,20 +54,22 @@
       annotateChart({{ target.ra }}, {{ target.dec }});
     });
 
-    function getFovFromForm() {
-      return Number($('#fov').val());
+    function getScaleBarFromForm() {
+      const size = $('#scale-bar-size').val() || '1';
+      const units = $('input[name=scale-bar-units]:checked', '#chart-form').val() || 'arcmin';
+      const label = size + ' ' + units;
+      const sizeAsDegrees = toDegrees(Number(size), units);
+      return {size: Number(size), units: units, label: label, sizeAsDegrees: sizeAsDegrees};
     }
 
-    function getScaleBarUnitsFromForm() {
-      return $('input[name=scale-bar-units]:checked', '#chart-form').val();
-    }
-
-    function getFovUnitsFromForm() {
-      return $('input[name=fov-units]:checked', '#chart-form').val();
-    }
-
-    function getScaleBarSizeFromForm() {
-      return Number($('#scale-bar-size').val());
+    function getFovAsDegreesFromForm() {
+      const fov = Number($('#fov').val());
+      const units = $('input[name=fov-units]:checked', '#chart-form').val();
+      let fovAsDegrees;
+      if (fov && units) {
+        fovAsDegrees = toDegrees(fov, units);
+      }
+      return fovAsDegrees;
     }
 
     function toDegrees(value, units) {
@@ -82,11 +84,10 @@
 
     function annotateChart(targetRa, targetDec) {
       const fov = aladin.getFov()[0]; // Returns decimal degrees
-      const scaleBarSize = getScaleBarSizeFromForm() || 1;
-      const scaleBarUnits = getScaleBarUnitsFromForm() || 'arcsec';
+      const scaleBar = getScaleBarFromForm();
       // Pixel position (0,0) is the top left corner of the view
       const viewSizePix = aladin.getSize();
-      const offsetPixFromEdge = 15;
+      const offsetPixFromEdge = 25;
       const scaleBarStartPix = [offsetPixFromEdge, viewSizePix[1] - offsetPixFromEdge]; // Bottom left corner
       const compassCenterPix = [viewSizePix[0] - offsetPixFromEdge, viewSizePix[1] - offsetPixFromEdge]; // Bottom right corner
       // Compass position
@@ -99,16 +100,16 @@
       const compassEastArmPix = aladin.world2pix(compassEastArm[0], compassEastArm[1]);
       // Scale bar position
       const scaleBarStart = aladin.pix2world(scaleBarStartPix[0], scaleBarStartPix[1]);
-      const scaleBarEnd = [scaleBarStart[0] - toDegrees(scaleBarSize, scaleBarUnits), scaleBarStart[1]]
+      const scaleBarEnd = [scaleBarStart[0] - scaleBar.sizeAsDegrees, scaleBarStart[1]]
       // Re-draw the annotations on the chart
       const color = '#f72525';
       aladin.removeLayers();
-      let layer = A.graphicOverlay({name: 'chart annotations', color: color, lineWidth: 1});
+      let layer = A.graphicOverlay({name: 'chart annotations', color: color, lineWidth: 2});
       aladin.addOverlay(layer);
       layer.add(A.polyline([compassNorthArm, compassCenter, compassEastArm]));
       layer.add(A.polyline([scaleBarStart, scaleBarEnd]));
       layer.add(A.circle(targetRa, targetDec, fov / 30));
-      layer.add(new Text(scaleBarStartPix[0], scaleBarStartPix[1] - 10, String(scaleBarSize) + ' ' + scaleBarUnits, {color: color}));
+      layer.add(new Text(scaleBarStartPix[0], scaleBarStartPix[1] - 10, scaleBar.label, {color: color}));
       layer.add(new Text(compassNorthArmPix[0], compassNorthArmPix[1] - 5, 'N', {color: color}));
       layer.add(new Text(compassEastArmPix[0] - 10, compassEastArmPix[1], 'E', {color: color}));
     }
@@ -120,27 +121,27 @@
     }
 
     function updateFromForm(ra, dec) {
-      const fov = getFovFromForm();
-      const fovUnits = getFovUnitsFromForm();
-      if (fov && fovUnits) {
-        aladin.setFov(toDegrees(fov, fovUnits));
+      const fov = getFovAsDegreesFromForm();
+      if (fov) {
+        aladin.setFov(fov);
         annotateChart(ra, dec);
       }
     }
 
     Text = (function() {
+      // The AladinLite API does not provide a way to draw arbitrary text at an arbitrary location in an overlay layer.
+      // This implements the methods necessary to do so when provided as an input to layer.add(). This approach was
+      // preferable to the others (possibilities included directly getting and drawing on the actual canvas element that the
+      // other overlay elements are drawn on, or creating another canvas element and placing it directly on top of
+      // the others) as the text that is drawn will then be integrated with the draw/destroy/redraw loops within aladin,
+      // and the text will show up in the generated data url that is used for saving an image without having to do anything extra.
 
-      // TODO: Add description
-
-      // constructor
       Text = function(x, y, text, options) {
         options = options || {};
         this.x = x || undefined;
         this.y = y || undefined;
         this.text = text || '';
         this.color = options['color'] || undefined;
-        // // TODO : all graphic overlays should have an id
-        // this.id = 'text';
         this.overlay = null;
       };
 

--- a/tom_targets/templates/tom_targets/partials/aladin.html
+++ b/tom_targets/templates/tom_targets/partials/aladin.html
@@ -83,16 +83,16 @@
     }
 
     function annotateChart(targetRa, targetDec) {
-      const fov = aladin.getFov()[0]; // Returns decimal degrees
+      const fovDegrees = aladin.getFov()[0];
       const scaleBar = getScaleBarFromForm();
       // Pixel position (0,0) is the top left corner of the view
       const viewSizePix = aladin.getSize();
-      const offsetPixFromEdge = 25;
+      const offsetPixFromEdge = 30;
       const scaleBarStartPix = [offsetPixFromEdge, viewSizePix[1] - offsetPixFromEdge]; // Bottom left corner
       const compassCenterPix = [viewSizePix[0] - offsetPixFromEdge, viewSizePix[1] - offsetPixFromEdge]; // Bottom right corner
       // Compass position
       // TODO: Will North/ East arms ever not be up/ to the left? In that case the placement will be wrong
-      const compassArmLength = fov / 10;
+      const compassArmLength = fovDegrees / 10;
       const compassCenter = aladin.pix2world(compassCenterPix[0], compassCenterPix[1]);
       const compassNorthArm = [compassCenter[0], compassCenter[1] + compassArmLength];
       const compassNorthArmPix = aladin.world2pix(compassNorthArm[0], compassNorthArm[1]);
@@ -100,18 +100,22 @@
       const compassEastArmPix = aladin.world2pix(compassEastArm[0], compassEastArm[1]);
       // Scale bar position
       const scaleBarStart = aladin.pix2world(scaleBarStartPix[0], scaleBarStartPix[1]);
-      const scaleBarEnd = [scaleBarStart[0] - scaleBar.sizeAsDegrees, scaleBarStart[1]]
+      const scaleBarEnd = [scaleBarStart[0] - scaleBar.sizeAsDegrees, scaleBarStart[1]];
+      const scaleBarEndPix = aladin.world2pix(scaleBarEnd[0], scaleBarEnd[1]);
+      const scaleBarLength = scaleBarEndPix[0] - scaleBarStartPix[0];
       // Re-draw the annotations on the chart
       const color = '#f72525';
+      const scaleBarTextSpacing = 7;
+      const compassTextSpacing = 3;
       aladin.removeLayers();
       let layer = A.graphicOverlay({name: 'chart annotations', color: color, lineWidth: 2});
       aladin.addOverlay(layer);
       layer.add(A.polyline([compassNorthArm, compassCenter, compassEastArm]));
       layer.add(A.polyline([scaleBarStart, scaleBarEnd]));
-      layer.add(A.circle(targetRa, targetDec, fov / 30));
-      layer.add(new Text(scaleBarStartPix[0], scaleBarStartPix[1] - 10, scaleBar.label, {color: color}));
-      layer.add(new Text(compassNorthArmPix[0], compassNorthArmPix[1] - 5, 'N', {color: color}));
-      layer.add(new Text(compassEastArmPix[0] - 10, compassEastArmPix[1], 'E', {color: color}));
+      layer.add(A.circle(targetRa, targetDec, fovDegrees / 30));
+      layer.add(new Text(scaleBarStartPix[0] + scaleBarLength/2, scaleBarStartPix[1] - scaleBarTextSpacing, scaleBar.label, {color: color}));
+      layer.add(new Text(compassNorthArmPix[0], compassNorthArmPix[1] - compassTextSpacing, 'N', {color: color}));
+      layer.add(new Text(compassEastArmPix[0] - compassTextSpacing, compassEastArmPix[1], 'E', {color: color, align: 'end', baseline: 'middle'}));
     }
 
     function downloadImage() {
@@ -142,6 +146,8 @@
         this.y = y || undefined;
         this.text = text || '';
         this.color = options['color'] || undefined;
+        this.align = options['align'] || 'center';
+        this.baseline = options['baseline'] || 'alphabetic';
         this.overlay = null;
       };
 
@@ -151,7 +157,9 @@
 
       Text.prototype.draw = function(ctx) {
         ctx.fillStyle = this.color;
-        ctx.font = "12px Arial";
+        ctx.font = '15px Arial';
+        ctx.textAlign = this.align;
+        ctx.textBaseline = this.baseline;
         ctx.fillText(this.text, this.x, this.y);
       };
 

--- a/tom_targets/templates/tom_targets/partials/aladin.html
+++ b/tom_targets/templates/tom_targets/partials/aladin.html
@@ -102,18 +102,18 @@
       const scaleBarStartPix = [offsetPixFromEdge, viewSizePix[1] - offsetPixFromEdge]; // Bottom left corner
       const compassCenterPix = [viewSizePix[0] - offsetPixFromEdge, viewSizePix[1] - offsetPixFromEdge]; // Bottom right corner
       // Compass position
-      // TODO: Will North/ East arms ever not be up/ to the left? In that case the placement will be wrong
+      const cosDec = Math.cos(targetDec * Math.PI / 180);
       const compassArmLength = fovDegrees / 10;
       const compassCenter = aladin.pix2world(compassCenterPix[0], compassCenterPix[1]);
       const compassNorthArm = [compassCenter[0], compassCenter[1] + compassArmLength];
       const compassNorthArmPix = aladin.world2pix(compassNorthArm[0], compassNorthArm[1]);
-      const compassEastArm = [compassCenter[0] + compassArmLength, compassCenter[1]];
+      const compassEastArm = [compassCenter[0] + compassArmLength / cosDec, compassCenter[1]];
       const compassEastArmPix = aladin.world2pix(compassEastArm[0], compassEastArm[1]);
       // Scale bar position
       const scaleBarStart = aladin.pix2world(scaleBarStartPix[0], scaleBarStartPix[1]);
-      const scaleBarEnd = [scaleBarStart[0] - scaleBar.sizeAsDegrees, scaleBarStart[1]];
+      const scaleBarEnd = [scaleBarStart[0] - scaleBar.sizeAsDegrees / cosDec, scaleBarStart[1]];
       const scaleBarEndPix = aladin.world2pix(scaleBarEnd[0], scaleBarEnd[1]);
-      const scaleBarLength = scaleBarEndPix[0] - scaleBarStartPix[0];
+      const scaleBarLength = Math.abs(scaleBarEndPix[0] - scaleBarStartPix[0]);
       // Re-draw the annotations on the chart
       const color = '#f72525';
       const scaleBarTextSpacing = 7;
@@ -124,7 +124,7 @@
       layer.add(A.polyline([compassNorthArm, compassCenter, compassEastArm]));
       layer.add(A.polyline([scaleBarStart, scaleBarEnd]));
       layer.add(A.circle(targetRa, targetDec, fovDegrees / 30));
-      layer.add(new Text(scaleBarStartPix[0] + scaleBarLength/2, scaleBarStartPix[1] - scaleBarTextSpacing, scaleBar.label, {color: color}));
+      layer.add(new Text(scaleBarStartPix[0] + scaleBarLength / 2, scaleBarStartPix[1] - scaleBarTextSpacing, scaleBar.label, {color: color}));
       layer.add(new Text(compassNorthArmPix[0], compassNorthArmPix[1] - compassTextSpacing, 'N', {color: color}));
       layer.add(new Text(compassEastArmPix[0] - compassTextSpacing, compassEastArmPix[1], 'E', {color: color, align: 'end', baseline: 'middle'}));
     }

--- a/tom_targets/templates/tom_targets/partials/aladin.html
+++ b/tom_targets/templates/tom_targets/partials/aladin.html
@@ -3,16 +3,157 @@
 <!-- insert this snippet where you want Aladin Lite viewer to appear and after the loading of jQuery -->
 <h3>Survey View</h3>
 <div id="aladin-lite-div" style="width:300px;height:300px;"></div>
+<form id="chart-form">
+  <div class="form-group row">
+    <label for="fov">Field of view</label>
+    <input type="number" id="fov" name="fov" min="0" value="5">
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="radio" id="deg-fov-units" name="fov-units" value="deg" checked>
+      <label class="form-check-label" for="deg-fov-units">deg</label><br>
+      <input class="form-check-input" type="radio" id="arcmin-fov-units" name="fov-units" value="arcmin">
+      <label class="form-check-label" for="arcmin-fov-units">arcmin</label><br>
+      <input class="form-check-input" type="radio" id="arcsec-fov-units" name="fov-units" value="arcsec">
+      <label class="form-check-label" for="arcsec-fov-units">arcsec</label>
+    </div>
+  </div>
+  <div class="form-group row">
+    <label for="scale-bar-size">Scale bar size:</label>
+    <input type="number" id="scale-bar-size" name="scale-bar-size" min="0" value="1">
+    <div class="form-check form-check-inline">
+      <input type="radio" id="deg-scale-bar-units" name="scale-bar-units" value="deg" checked>
+      <label for="deg-scale-bar-units">deg</label><br>
+      <input type="radio" id="arcmin-scale-bar-units" name="scale-bar-units" value="arcmin">
+      <label for="arcmin-scale-bar-units">arcmin</label><br>
+      <input type="radio" id="arcsec-scale-bar-units" name="scale-bar-units" value="arcsec">
+      <label for="arcsec-scale-bar-units">arcsec</label>
+    </div>
+  </div>
+  <div class="form-group row">
+    <input class="btn btn-outline-primary" type="button" onclick="updateFromForm({{ target.ra }}, {{ target.dec }})" value="Update">
+    <a class="btn btn-outline-primary" id="download-chart" href="" download="chart.png" onclick="downloadImage()">Save Image</a>
+  </div>
+</form>
 <script type="text/javascript" src="//aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js" charset="utf-8"></script>
 <script type="text/javascript">
-    var aladin = A.aladin('#aladin-lite-div', {
+
+    let aladin = A.aladin('#aladin-lite-div', {
       survey: "P/DSS2/color",
-      fov:5,
+      fov: getFovFromForm(),
+      showReticle: false,
       target: "{{ target.ra }} {{ target.dec }}",
       showGotoControl: false,
+      showZoomControl: false,
+      allowFullZoomout: false
     });
-    var target_cat = A.catalog({name: '{{ target.name }}', sourceSize: 10, color: 'red'});
-    aladin.addCatalog(target_cat, {shape: 'circle'});
-    target_cat.addSources([A.marker({{ target.ra }}, {{ target.dec }}, 
-      {popupTitle: '{{ target.name }}'})]);
+
+    aladin.on('positionChanged', function() {
+      annotateChart({{ target.ra }}, {{ target.dec }});
+    });
+
+    aladin.on('zoomChanged', function() {
+      annotateChart({{ target.ra }}, {{ target.dec }});
+    });
+
+    function getFovFromForm() {
+      return Number($('#fov').val());
+    }
+
+    function getScaleBarUnitsFromForm() {
+      return $('input[name=scale-bar-units]:checked', '#chart-form').val();
+    }
+
+    function getFovUnitsFromForm() {
+      return $('input[name=fov-units]:checked', '#chart-form').val();
+    }
+
+    function getScaleBarSizeFromForm() {
+      return Number($('#scale-bar-size').val());
+    }
+
+    function toDegrees(value, units) {
+      if (units === 'arcmin') {
+        return value / 60;
+      } else if (units === 'arcsec') {
+        return value / 3600;
+      } else {
+        return value;
+      }
+    }
+
+    function annotateChart(targetRa, targetDec) {
+      const fov = aladin.getFov()[0]; // Returns decimal degrees
+      const scaleBarSize = getScaleBarSizeFromForm() || 1;
+      const scaleBarUnits = getScaleBarUnitsFromForm() || 'arcsec';
+      // Pixel position (0,0) is the top left corner of the view
+      const viewSizePix = aladin.getSize();
+      const offsetPixFromEdge = 15;
+      const scaleBarStartPix = [offsetPixFromEdge, viewSizePix[1] - offsetPixFromEdge]; // Bottom left corner
+      const compassCenterPix = [viewSizePix[0] - offsetPixFromEdge, viewSizePix[1] - offsetPixFromEdge]; // Bottom right corner
+      // Compass position
+      // TODO: Will North/ East arms ever not be up/ to the left? In that case the placement will be wrong
+      const compassArmLength = fov / 10;
+      const compassCenter = aladin.pix2world(compassCenterPix[0], compassCenterPix[1]);
+      const compassNorthArm = [compassCenter[0], compassCenter[1] + compassArmLength];
+      const compassNorthArmPix = aladin.world2pix(compassNorthArm[0], compassNorthArm[1]);
+      const compassEastArm = [compassCenter[0] + compassArmLength, compassCenter[1]];
+      const compassEastArmPix = aladin.world2pix(compassEastArm[0], compassEastArm[1]);
+      // Scale bar position
+      const scaleBarStart = aladin.pix2world(scaleBarStartPix[0], scaleBarStartPix[1]);
+      const scaleBarEnd = [scaleBarStart[0] - toDegrees(scaleBarSize, scaleBarUnits), scaleBarStart[1]]
+      // Re-draw the annotations on the chart
+      const color = '#f72525';
+      aladin.removeLayers();
+      let layer = A.graphicOverlay({name: 'chart annotations', color: color, lineWidth: 1});
+      aladin.addOverlay(layer);
+      layer.add(A.polyline([compassNorthArm, compassCenter, compassEastArm]));
+      layer.add(A.polyline([scaleBarStart, scaleBarEnd]));
+      layer.add(A.circle(targetRa, targetDec, fov / 30));
+      layer.add(new Text(scaleBarStartPix[0], scaleBarStartPix[1] - 10, String(scaleBarSize) + ' ' + scaleBarUnits, {color: color}));
+      layer.add(new Text(compassNorthArmPix[0], compassNorthArmPix[1] - 5, 'N', {color: color}));
+      layer.add(new Text(compassEastArmPix[0] - 10, compassEastArmPix[1], 'E', {color: color}));
+    }
+
+    function downloadImage() {
+      // Update the data that the link that was clicked will download
+      $('#download-chart').attr('href', aladin.getViewDataURL());
+      return true;
+    }
+
+    function updateFromForm(ra, dec) {
+      const fov = getFovFromForm();
+      const fovUnits = getFovUnitsFromForm();
+      if (fov && fovUnits) {
+        aladin.setFov(toDegrees(fov, fovUnits));
+        annotateChart(ra, dec);
+      }
+    }
+
+    Text = (function() {
+
+      // TODO: Add description
+
+      // constructor
+      Text = function(x, y, text, options) {
+        options = options || {};
+        this.x = x || undefined;
+        this.y = y || undefined;
+        this.text = text || '';
+        this.color = options['color'] || undefined;
+        // // TODO : all graphic overlays should have an id
+        // this.id = 'text';
+        this.overlay = null;
+      };
+
+      Text.prototype.setOverlay = function(overlay) {
+        this.overlay = overlay;
+      };
+
+      Text.prototype.draw = function(ctx) {
+        ctx.fillStyle = this.color;
+        ctx.font = "12px Arial";
+        ctx.fillText(this.text, this.x, this.y);
+      };
+
+      return Text;
+    })();
 </script>

--- a/tom_targets/templates/tom_targets/partials/aladin.html
+++ b/tom_targets/templates/tom_targets/partials/aladin.html
@@ -3,36 +3,44 @@
 <!-- insert this snippet where you want Aladin Lite viewer to appear and after the loading of jQuery -->
 <h3>Survey View</h3>
 <div id="aladin-lite-div" style="width:300px;height:300px;"></div>
-<form id="chart-form">
-  <div class="form-group row">
-    <label for="fov">Field of view</label>
-    <input type="number" id="fov" name="fov" min="0" value="10">
-    <div class="form-check form-check-inline">
-      <input class="form-check-input" type="radio" id="deg-fov-units" name="fov-units" value="deg">
-      <label class="form-check-label" for="deg-fov-units">deg</label><br>
-      <input class="form-check-input" type="radio" id="arcmin-fov-units" name="fov-units" value="arcmin" checked>
-      <label class="form-check-label" for="arcmin-fov-units">arcmin</label><br>
-      <input class="form-check-input" type="radio" id="arcsec-fov-units" name="fov-units" value="arcsec">
-      <label class="form-check-label" for="arcsec-fov-units">arcsec</label>
+<div id="chart-form-div" style="width:300px;">
+  <form id="chart-form">
+    <div class="form-group mt-1 mb-1">
+      <div class="input-group">
+        <div class="input-group-prepend">
+          <span class="input-group-text bg-transparent" style="font-family: inherit;">Field of view</span>
+        </div>
+        <input type="number" class="form-control" aria-label="Field of view" id="fov" min="0" value="10">
+        <div class="input-group-append">
+          <select id="fov-units-select" class="form-control">
+            <option>arcsec</option>
+            <option selected>arcmin</option>
+            <option>deg</option>
+          </select>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="form-group row">
-    <label for="scale-bar-size">Scale bar size:</label>
-    <input type="number" id="scale-bar-size" name="scale-bar-size" min="0" value="1">
-    <div class="form-check form-check-inline">
-      <input type="radio" id="deg-scale-bar-units" name="scale-bar-units" value="deg">
-      <label for="deg-scale-bar-units">deg</label><br>
-      <input type="radio" id="arcmin-scale-bar-units" name="scale-bar-units" value="arcmin" checked>
-      <label for="arcmin-scale-bar-units">arcmin</label><br>
-      <input type="radio" id="arcsec-scale-bar-units" name="scale-bar-units" value="arcsec">
-      <label for="arcsec-scale-bar-units">arcsec</label>
+    <div class="form-group mt-1 mb-1">
+      <div class="input-group">
+        <div class="input-group-prepend">
+          <label class="input-group-text bg-transparent" style="font-family: inherit;" for="scale-bar-units-select">Scale bar</label>
+        </div>
+        <input type="number" class="form-control" aria-label="Scale bar size" id="scale-bar-size" min="0" value="1">
+        <div class="input-group-append">
+          <select id="scale-bar-units-select" class="form-control">
+            <option>arcsec</option>
+            <option selected>arcmin</option>
+            <option>deg</option>
+          </select>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="form-group row">
-    <input class="btn btn-outline-primary" type="button" onclick="updateFromForm({{ target.ra }}, {{ target.dec }})" value="Update">
-    <a class="btn btn-outline-primary" id="download-chart" href="" download="chart.png" onclick="downloadImage()">Save Image</a>
-  </div>
-</form>
+    <div class="form-group mt-1 mb-1">
+      <input class="btn btn-primary" type="button" onclick="updateFromForm({{ target.ra }}, {{ target.dec }})" value="Update">
+      <a class="btn btn-primary" id="download-chart" href="" download="chart.png" onclick="downloadImage()">Save Image</a>
+    </div>
+  </form>
+</div>
 <script type="text/javascript" src="//aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js" charset="utf-8"></script>
 <script type="text/javascript">
 
@@ -56,7 +64,7 @@
 
     function getScaleBarFromForm() {
       const size = $('#scale-bar-size').val() || '1';
-      const units = $('input[name=scale-bar-units]:checked', '#chart-form').val() || 'arcmin';
+      const units = $('#scale-bar-units-select option:selected').val() || 'arcmin';
       const label = size + ' ' + units;
       const sizeAsDegrees = toDegrees(Number(size), units);
       return {size: Number(size), units: units, label: label, sizeAsDegrees: sizeAsDegrees};
@@ -64,7 +72,7 @@
 
     function getFovAsDegreesFromForm() {
       const fov = Number($('#fov').val());
-      const units = $('input[name=fov-units]:checked', '#chart-form').val();
+      const units = $('#fov-units-select option:selected').val();
       let fovAsDegrees;
       if (fov && units) {
         fovAsDegrees = toDegrees(fov, units);

--- a/tom_targets/templates/tom_targets/partials/moon_distance.html
+++ b/tom_targets/templates/tom_targets/partials/moon_distance.html
@@ -1,0 +1,3 @@
+<div id="lunar-plot">
+  {{ plot|safe }}
+</div>

--- a/tom_targets/templates/tom_targets/partials/target_buttons.html
+++ b/tom_targets/templates/tom_targets/partials/target_buttons.html
@@ -1,0 +1,2 @@
+<a href="{% url 'tom_targets:update' pk=target.id %}" title="Update target" class="btn  btn-primary">Update Target</a>
+<a href="{% url 'tom_targets:delete' pk=target.id %}" title="Delete target" class="btn  btn-warning">Delete Target</a>

--- a/tom_targets/templates/tom_targets/partials/target_data.html
+++ b/tom_targets/templates/tom_targets/partials/target_data.html
@@ -1,6 +1,4 @@
 {% load tom_common_extras targets_extras %}
-<a href="{% url 'tom_targets:update' pk=target.id %}" title="Update target" class="btn  btn-primary">Update Target</a>
-<a href="{% url 'tom_targets:delete' pk=target.id %}" title="Delete target" class="btn  btn-warning">Delete Target</a>
 <dl class="row">
   {% for target_name in target.names %}
     {% if forloop.first %}

--- a/tom_targets/templates/tom_targets/target_detail.html
+++ b/tom_targets/templates/tom_targets/target_detail.html
@@ -15,6 +15,7 @@
         {{ object.future_observations|length }} upcoming observation{{ object.future_observations|pluralize }}
       </div>
       {% endif %}
+      {% target_buttons object %}
       {% target_data object %}
       {% if object.type == 'SIDEREAL' %}
       {% aladin object %}
@@ -51,9 +52,10 @@
         <hr/>
         <h4>Plan</h4>
         {% if object.type == 'SIDEREAL' %}
-            {% target_plan %}
+          {% target_plan %}
+          {% moon_distance object %}
         {% elif target.type == 'NON_SIDEREAL' %}
-            <p>Airmass plotting for non-sidereal targets is not currently supported. If you would like to add this functionality, please check out the <a href="https://github.com/TOMToolkit/tom_nonsidereal_airmass" target="_blank">non-sidereal airmass plugin.</a></p>
+          <p>Airmass plotting for non-sidereal targets is not currently supported. If you would like to add this functionality, please check out the <a href="https://github.com/TOMToolkit/tom_nonsidereal_airmass" target="_blank">non-sidereal airmass plugin.</a></p>
         {% endif %}
       </div>
       <div class="tab-pane" id="observations">

--- a/tom_targets/templates/tom_targets/target_detail.html
+++ b/tom_targets/templates/tom_targets/target_detail.html
@@ -16,7 +16,9 @@
       </div>
       {% endif %}
       {% target_data object %}
+      {% if object.type == 'SIDEREAL' %}
       {% aladin object %}
+      {% endif %}
     </div>
   </div>
   <div class="col-md-8">

--- a/tom_targets/templatetags/targets_extras.py
+++ b/tom_targets/templatetags/targets_extras.py
@@ -176,6 +176,7 @@ def select_target_js():
 @register.inclusion_tag('tom_targets/partials/aladin.html')
 def aladin(target):
     """
-    Displays Aladin skyview of the given target.
+    Displays Aladin skyview of the given target along with basic finder chart annotations including a compass
+    and a scale bar. The resulting image is downloadable. This templatetag only works for sidereal targets.
     """
     return {'target': target}

--- a/tom_targets/templatetags/targets_extras.py
+++ b/tom_targets/templatetags/targets_extras.py
@@ -1,9 +1,14 @@
+from datetime import datetime, timedelta
+
+from astroplan import moon_illumination
 from astropy import units as u
-from astropy.coordinates import Angle
+from astropy.coordinates import Angle, get_moon, SkyCoord
+from astropy.time import Time
 from dateutil.parser import parse
 from django import template
 from django.conf import settings
 from guardian.shortcuts import get_objects_for_user
+import numpy as np
 from plotly import offline
 from plotly import graph_objs as go
 
@@ -27,6 +32,14 @@ def recent_targets(context, limit=10):
 def target_feature(target):
     """
     Displays the featured image for a target.
+    """
+    return {'target': target}
+
+
+@register.inclusion_tag('tom_targets/partials/target_buttons.html')
+def target_buttons(target):
+    """
+    Displays the Update and Delete buttons for a target.
     """
     return {'target': target}
 
@@ -89,6 +102,58 @@ def target_plan(context):
         'target': context['object'],
         'visibility_graph': visibility_graph
     }
+
+
+@register.inclusion_tag('tom_targets/partials/moon_distance.html')
+def moon_distance(target, day_range=30):
+    """
+    Renders plot for lunar distance from target.
+
+    Adapted from Jamison Frost Burke's moon visibility code in Supernova Exchange 2.0, as seen here:
+    https://github.com/jfrostburke/snex2/blob/0c1eb184c942cb10f7d54084e081d8ac11700edf/custom_code/templatetags/custom_code_tags.py#L196
+
+    :param target: Target object for which moon distance is calculated
+    :type target: tom_targets.models.Target
+
+    :param day_range: Number of days to plot lunar distance
+    :type day_range: int
+    """
+
+    day_range = 30
+    times = Time(
+        [str(datetime.utcnow() + timedelta(days=delta)) for delta in np.arange(0, day_range, 0.2)],
+        format='iso', scale='utc'
+    )
+
+    obj_pos = SkyCoord(target.ra, target.dec, unit=u.deg)
+    moon_pos = get_moon(times)
+
+    separations = moon_pos.separation(obj_pos).deg
+    phases = moon_illumination(times)
+
+    distance_color = 'rgb(0, 0, 255)'
+    phase_color = 'rgb(255, 0, 0)'
+    plot_data = [
+        go.Scatter(x=times.mjd-times[0].mjd, y=separations, mode='lines', name='Moon distance (degrees)',
+                   line=dict(color=distance_color)),
+        go.Scatter(x=times.mjd-times[0].mjd, y=phases, mode='lines', name='Moon phase', yaxis='y2',
+                   line=dict(color=phase_color))
+    ]
+    layout = go.Layout(
+                xaxis={'title': 'Days from now'},
+                yaxis={'range': [0, 180], 'tick0': 0, 'dtick': 45, 'tickfont': {'color': distance_color}},
+                yaxis2={'range': [0, 1], 'tick0': 0, 'dtick': 0.25, 'overlaying': 'y', 'side': 'right',
+                        'tickfont': {'color': phase_color}},
+                margin={'l': 20, 'r': 10, 'b': 30, 't': 40},
+                width=600,
+                height=300,
+                autosize=True
+            )
+    moon_distance_plot = offline.plot(
+        go.Figure(data=plot_data, layout=layout), output_type='div', show_link=False
+    )
+
+    return {'plot': moon_distance_plot}
 
 
 @register.inclusion_tag('tom_targets/partials/target_distribution.html')

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -610,7 +610,7 @@ class TestTargetAddRemoveGrouping(TestCase):
             'selected-target': [self.fake_targets[0].id, self.fake_targets[1].id],
             'query_string': '',
         }
-        self.client.post(reverse('targets:add-remove-grouping'), data=data)
+        response = self.client.post(reverse('targets:add-remove-grouping'), data=data)
 
         self.assertEqual(self.fake_grouping.targets.count(), 2)
         self.assertTrue(self.fake_targets[0] in self.fake_grouping.targets.all())

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -2,7 +2,8 @@ import pytz
 from datetime import datetime
 
 from django.contrib.auth.models import User, Group
-from django.core import serializers
+from django.contrib.messages import get_messages
+from django.contrib.messages.constants import SUCCESS, WARNING
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
@@ -68,7 +69,7 @@ class TestTargetDetail(TestCase):
     def setUp(self):
         user = User.objects.create(username='testuser')
         self.client.force_login(user)
-        self.st = SiderealTargetFactory.create()
+        self.st = SiderealTargetFactory.create(ra=123.456, dec=-32.1)
         self.nst = NonSiderealTargetFactory.create()
         assign_perm('tom_targets.view_target', user, self.st)
         assign_perm('tom_targets.view_target', user, self.nst)
@@ -435,6 +436,51 @@ class TestTargetImport(TestCase):
                 self.assertTrue(TargetName.objects.filter(target=target, name=alias).exists())
 
 
+class TestTargetExport(TestCase):
+    """
+    The use of a list to handle the map returned by StreamingHttpResponse.streaming_content is taken directly from
+    the Django httpwrappers tests, as seen here:
+    https://github.com/django/django/blob/00ff7a44dee91be59a64559cadeeba0f7386fd6f/tests/httpwrappers/tests.py#L569
+
+    Tests are included for targets with and without aliases due to the previous presence of a bug relating to aliases
+    and target export: https://github.com/TOMToolkit/tom_base/issues/265
+    """
+    def setUp(self):
+        self.st = SiderealTargetFactory.create(name='M42', ra=83.8221, dec=-5.3911)
+        self.st2 = SiderealTargetFactory.create(name='M52', ra=351.2, dec=61.593)
+
+        self.user = User.objects.create(username='testuser')
+        self.client.force_login(self.user)
+        assign_perm('tom_targets.view_target',  self.user, self.st)
+        assign_perm('tom_targets.view_target',  self.user, self.st2)
+
+    def test_export_all_targets_no_aliases(self):
+        response = self.client.get(reverse('targets:export'))
+        content = ''.join(line.decode('utf-8') for line in list(response.streaming_content))
+        self.assertIn('M42', content)
+        self.assertIn('M52', content)
+
+    def test_export_filtered_targets_no_aliases(self):
+        response = self.client.get(reverse('targets:export') + '?name=M42')
+        content = ''.join(line.decode('utf-8') for line in list(response.streaming_content))
+        self.assertIn('M42', content)
+        self.assertNotIn('M52', content)
+
+    def test_export_all_targets_with_aliases(self):
+        st_name = TargetNameFactory.create(name='Messier 42', target=self.st)
+        response = self.client.get(reverse('targets:export'))
+        content = ''.join(line.decode('utf-8') for line in list(response.streaming_content))
+        self.assertIn('M42', content)
+        self.assertIn('M52', content)
+
+    def test_export_filtered_targets_with_aliases(self):
+        st_name = TargetNameFactory.create(name='Messier 42', target=self.st)
+        response = self.client.get(reverse('targets:export') + '?name=M42')
+        content = ''.join(line.decode('utf-8') for line in list(response.streaming_content))
+        self.assertIn('M42', content)
+        self.assertNotIn('M52', content)
+
+
 class TestTargetSearch(TestCase):
     def setUp(self):
         self.st = SiderealTargetFactory.create(name='1337target', ra=269.9983, dec=-29.0698)
@@ -570,6 +616,12 @@ class TestTargetAddRemoveGrouping(TestCase):
         self.assertTrue(self.fake_targets[0] in self.fake_grouping.targets.all())
         self.assertTrue(self.fake_targets[1] in self.fake_grouping.targets.all())
 
+        messages = [(m.message, m.level) for m in get_messages(response.wsgi_request)]
+        self.assertIn(('1 target(s) successfully added to group \'{}\'.'.format(self.fake_grouping.name),
+                       SUCCESS), messages)
+        self.assertIn(('1 target(s) already in group \'{}\': {}'.format(
+            self.fake_grouping.name, self.fake_targets[0].name), WARNING), messages)
+
     def test_add_to_invalid_grouping(self):
         data = {
             'grouping': -1,
@@ -578,9 +630,11 @@ class TestTargetAddRemoveGrouping(TestCase):
             'selected-target': self.fake_targets[1].id,
             'query_string': '',
         }
-        self.client.post(reverse('targets:add-remove-grouping'), data=data)
+        response = self.client.post(reverse('targets:add-remove-grouping'), data=data)
         self.assertEqual(self.fake_grouping.targets.count(), 1)
         self.assertTrue(self.fake_targets[0] in self.fake_grouping.targets.all())
+        messages = [(m.message, m.level) for m in get_messages(response.wsgi_request)]
+        self.assertTrue('Cannot find the target group with id=-1; ' in messages[0][0])
 
     # Remove target[0] and [1] from grouping;
     def test_remove_selected_from_grouping(self):
@@ -591,8 +645,13 @@ class TestTargetAddRemoveGrouping(TestCase):
             'selected-target': [self.fake_targets[0].id, self.fake_targets[1].id],
             'query_string': '',
         }
-        self.client.post(reverse('targets:add-remove-grouping'), data=data)
+        response = self.client.post(reverse('targets:add-remove-grouping'), data=data)
         self.assertEqual(self.fake_grouping.targets.count(), 0)
+        messages = [(m.message, m.level) for m in get_messages(response.wsgi_request)]
+        self.assertIn(('1 target(s) successfully removed from group \'{}\'.'.format(self.fake_grouping.name),
+                       SUCCESS), messages)
+        self.assertIn(('1 target(s) not in group \'{}\': {}'.format(self.fake_grouping.name, self.fake_targets[1].name),
+                       WARNING), messages)
 
     def test_empty_data(self):
         self.client.post(reverse('targets:add-remove-grouping'), data={'query_string': ''})
@@ -621,6 +680,13 @@ class TestTargetAddRemoveGrouping(TestCase):
         }
         response = self.client.post(reverse('targets:add-remove-grouping'), data=data)
         self.assertEqual(self.fake_grouping.targets.count(), 3)
+        messages = [(m.message, m.level) for m in get_messages(response.wsgi_request)]
+        self.assertIn(('2 target(s) successfully added to group \'{}\'.'.format(self.fake_grouping.name),
+                       SUCCESS), messages)
+        self.assertIn((
+            '1 target(s) already in group \'{}\': {}'.format(self.fake_grouping.name, self.fake_targets[0].name),
+            WARNING), messages
+        )
 
     def test_remove_all_from_grouping_filtered_by_sidereal(self):
         data = {
@@ -632,6 +698,12 @@ class TestTargetAddRemoveGrouping(TestCase):
         }
         response = self.client.post(reverse('targets:add-remove-grouping'), data=data)
         self.assertEqual(self.fake_grouping.targets.count(), 0)
+        messages = [(m.message, m.level) for m in get_messages(response.wsgi_request)]
+        self.assertIn(('1 target(s) successfully removed from group \'{}\'.'.format(self.fake_grouping.name),
+                       SUCCESS), messages)
+        self.assertIn(('2 target(s) not in group \'{}\': {}'.format(
+            self.fake_grouping.name, self.fake_targets[1].name + ', ' + self.fake_targets[2].name
+        ), WARNING), messages)
 
     def test_remove_all_from_grouping_filtered_by_grouping(self):
         data = {
@@ -643,6 +715,9 @@ class TestTargetAddRemoveGrouping(TestCase):
         }
         response = self.client.post(reverse('targets:add-remove-grouping'), data=data)
         self.assertEqual(self.fake_grouping.targets.count(), 0)
+        messages = [(m.message, m.level) for m in get_messages(response.wsgi_request)]
+        self.assertIn(('1 target(s) successfully removed from group \'{}\'.'.format(self.fake_grouping.name),
+                       SUCCESS), messages)
 
     def test_add_remove_with_random_query_string(self):
         data = {
@@ -662,11 +737,17 @@ class TestTargetAddRemoveGrouping(TestCase):
             'isSelectAll': 'True',
             'selected-target': [],
         }
-        self.client.post(reverse('targets:add-remove-grouping'), data=data)
+        response = self.client.post(reverse('targets:add-remove-grouping'), data=data)
         self.assertEqual(self.fake_grouping.targets.count(), 0)
+        messages = [(m.message, m.level) for m in get_messages(response.wsgi_request)]
+        self.assertIn(('1 target(s) successfully removed from group \'{}\'.'.format(self.fake_grouping.name),
+                       SUCCESS), messages)
+        self.assertIn(('2 target(s) not in group \'{}\': {}'.format(
+            self.fake_grouping.name, self.fake_targets[1].name + ', ' + self.fake_targets[2].name
+        ), WARNING), messages)
 
     def test_persist_filter(self):
-        data = {'query_string': "type=SIDEREAL&name=B&key=C&value=123&targetlist__name=1"}
+        data = {'query_string': 'type=SIDEREAL&name=B&key=C&value=123&targetlist__name=1'}
         expected_query_dict = {
             'type': 'SIDEREAL',
             'name': 'B',
@@ -678,8 +759,7 @@ class TestTargetAddRemoveGrouping(TestCase):
         self.assertEqual(response_query_dict, expected_query_dict)
 
     def test_persist_filter_empty(self):
-        data = {}
         expected_query_dict = {}
-        response = self.client.post(reverse('targets:add-remove-grouping'), data=data, follow=True)
+        response = self.client.post(reverse('targets:add-remove-grouping'), data={}, follow=True)
         response_query_dict = response.context['filter'].data
         self.assertEqual(response_query_dict, expected_query_dict)

--- a/tom_targets/utils.py
+++ b/tom_targets/utils.py
@@ -25,8 +25,10 @@ def export_targets(qs):
     # Gets the count of the target names for the target with the most aliases in the database
     # This is to construct enough row headers of format "name2, name3, name4, etc" for exporting aliases
     # The alias headers are then added to the set of fields for export
-    max_alias_count = max([alias['count'] for alias
-                           in TargetName.objects.values('target_id').annotate(count=Count('target_id'))])
+    aliases = TargetName.objects.filter(target__in=qs_pk).values('target_id').annotate(count=Count('target_id'))
+    max_alias_count = 0
+    if aliases:
+        max_alias_count = max([alias['count'] for alias in aliases])
     all_fields = target_fields + target_extra_fields + [f'name{index+1}' for index in range(1, max_alias_count+1)]
     for key in ['id', 'targetlist', 'dataproduct', 'observationrecord', 'reduceddatum', 'aliases', 'targetextra']:
         all_fields.remove(key)


### PR DESCRIPTION
Adds basic finder chart annotations to the aladin viewer on the target details page.

Additions include:
- Set the field of view
- Circle the target on the aladin image
- Compass drawn on the aladin image
- Scale bar of configurable size drawn on the aladin image
- Ability to save the resulting image

This only applies to sidereal targets. I also excluded the aladin viewer from being displayed for non-sidereal targets because it does not work with those target types.

Between a range of declinations from -85 to 85 degrees, within which most targets are expected to reside, the finder chart annotations look nice and clean. Outside of that range, as the target approaches a pole, they start getting more and more lopsided. This is a general issue when working close to the poles, and seeing as it probably will not affect most targets, I think it can be addressed at a later date to improve the annotations when close to the poles.

I made sure the style of the UI elements that were added match the look and feel of the rest of the target details page.

Here is a finder chart that was generated with this branch for m88, with a field of view of 10 arcmin.
![m88_10arcminFOV](https://user-images.githubusercontent.com/8227676/77690698-a362da00-6f9b-11ea-8273-ce5887942dcd.png)
