### PR TITLE
Feature/obs workflow

### DIFF
--- a/tom_observations/templates/tom_observations/observation_form.html
+++ b/tom_observations/templates/tom_observations/observation_form.html
@@ -1,8 +1,22 @@
 {% extends 'tom_common/base.html' %}
-{% load bootstrap4 crispy_forms_tags observation_extras %}
+{% load bootstrap4 crispy_forms_tags observation_extras targets_extras %}
 {% block title %}Submit Observation{% endblock %}
 {% block content %}
 <h3>Submit an observation to {{ form.facility.value }}</h3>
-{% observation_type_tabs %}
-{% crispy form %}
+{% if target.type == 'SIDEREAL' %}
+<div class="row">
+    <div class="col">
+    {% observation_plan target form.facility.value %}
+    </div>
+</div>
+{% endif %}
+<div class="row">
+    <div class="col-md-4">
+        {% target_data target %}
+    </div>
+    <div class="col-md-8">
+        {% observation_type_tabs %}
+        {% crispy form %}
+    </div>
+</div>
 {% endblock %}

--- a/tom_observations/templates/tom_observations/partials/observation_plan.html
+++ b/tom_observations/templates/tom_observations/partials/observation_plan.html
@@ -1,0 +1,4 @@
+{% load bootstrap4 %}
+<div id="plan-panel">
+  {{ visibility_graph|safe }}
+</div>

--- a/tom_observations/templatetags/observation_extras.py
+++ b/tom_observations/templatetags/observation_extras.py
@@ -41,6 +41,31 @@ def observation_type_tabs(context):
     }
 
 
+@register.inclusion_tag('tom_observations/partials/observation_plan.html')
+def observation_plan(target, facility, length=7, interval=60, airmass_limit=None):
+    """
+    Displays form and renders plot for visibility calculation. Using this templatetag to render a plot requires that
+    the context of the parent view have values for start_time, end_time, and airmass.
+    """
+
+    visibility_graph = ''
+    start_time = datetime.now()
+    end_time = start_time + timedelta(days=length)
+
+    visibility_data = get_sidereal_visibility(target, start_time, end_time, interval, airmass_limit)
+    plot_data = [
+        go.Scatter(x=data[0], y=data[1], mode='lines', name=site) for site, data in visibility_data.items()
+    ]
+    layout = go.Layout(yaxis=dict(autorange='reversed'))
+    visibility_graph = offline.plot(
+        go.Figure(data=plot_data, layout=layout), output_type='div', show_link=False
+    )
+
+    return {
+        'visibility_graph': visibility_graph
+    }
+
+
 @register.inclusion_tag('tom_observations/partials/observation_list.html')
 def observation_list(target=None):
     """

--- a/tom_observations/templatetags/observation_extras.py
+++ b/tom_observations/templatetags/observation_extras.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
 from django import forms, template

--- a/tom_observations/templatetags/observation_extras.py
+++ b/tom_observations/templatetags/observation_extras.py
@@ -7,6 +7,7 @@ import plotly.graph_objs as go
 from tom_observations.models import ObservationRecord
 from tom_observations.facility import get_service_classes
 from tom_observations.observing_strategy import RunStrategyForm
+from tom_observations.utils import get_sidereal_visibility
 from tom_targets.models import Target
 
 

--- a/tom_observations/views.py
+++ b/tom_observations/views.py
@@ -170,6 +170,8 @@ class ObservationCreateView(LoginRequiredMixin, FormView):
         """
         context = super(ObservationCreateView, self).get_context_data(**kwargs)
         context['type_choices'] = self.get_facility_class().observation_types
+        target = Target.objects.get(pk=self.get_target_id())
+        context['target'] = target
         return context
 
     def get_form_class(self):

--- a/tom_targets/templates/tom_targets/partials/target_buttons.html
+++ b/tom_targets/templates/tom_targets/partials/target_buttons.html
@@ -1,0 +1,2 @@
+<a href="{% url 'tom_targets:update' pk=target.id %}" title="Update target" class="btn  btn-primary">Update Target</a>
+<a href="{% url 'tom_targets:delete' pk=target.id %}" title="Delete target" class="btn  btn-warning">Delete Target</a>

--- a/tom_targets/templates/tom_targets/partials/target_data.html
+++ b/tom_targets/templates/tom_targets/partials/target_data.html
@@ -1,6 +1,4 @@
 {% load tom_common_extras targets_extras %}
-<a href="{% url 'tom_targets:update' pk=target.id %}" title="Update target" class="btn  btn-primary">Update Target</a>
-<a href="{% url 'tom_targets:delete' pk=target.id %}" title="Delete target" class="btn  btn-warning">Delete Target</a>
 <dl class="row">
   {% for target_name in target.names %}
     {% if forloop.first %}

--- a/tom_targets/templates/tom_targets/target_detail.html
+++ b/tom_targets/templates/tom_targets/target_detail.html
@@ -15,6 +15,7 @@
         {{ object.future_observations|length }} upcoming observation{{ object.future_observations|pluralize }}
       </div>
       {% endif %}
+      {% target_buttons object %}
       {% target_data object %}
       {% aladin object %}
     </div>

--- a/tom_targets/templatetags/targets_extras.py
+++ b/tom_targets/templatetags/targets_extras.py
@@ -36,6 +36,14 @@ def target_feature(target):
     return {'target': target}
 
 
+@register.inclusion_tag('tom_targets/partials/target_buttons.html')
+def target_buttons(target):
+    """
+    Displays the Update and Delete buttons for a target.
+    """
+    return {'target': target}
+
+
 @register.inclusion_tag('tom_targets/partials/target_data.html')
 def target_data(target):
     """


### PR DESCRIPTION
This addresses some of the issues raised concerning the observation workflow. It does the following:

- Separates target update/delete buttons into their own templatetag.
- Adds an airmass plot and target details to the observation submission page.
- Adds the target to the context of the observation submission view.

This pull request will need to be merged prior to the changes to the tom-demo.