### PR TITLE
Fixed issue with no aliases causing crash on target export and added …

### DIFF
--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -386,7 +386,7 @@ class TestTargetImport(TestCase):
 
 class TestTargetExport(TestCase):
     """
-    The use of a list to handle the map returned by StreamingHttpResponse.streaming_content is taken directly from 
+    The use of a list to handle the map returned by StreamingHttpResponse.streaming_content is taken directly from
     the Django httpwrappers tests, as seen here:
     https://github.com/django/django/blob/00ff7a44dee91be59a64559cadeeba0f7386fd6f/tests/httpwrappers/tests.py#L569
 

--- a/tom_targets/utils.py
+++ b/tom_targets/utils.py
@@ -25,8 +25,10 @@ def export_targets(qs):
     # Gets the count of the target names for the target with the most aliases in the database
     # This is to construct enough row headers of format "name2, name3, name4, etc" for exporting aliases
     # The alias headers are then added to the set of fields for export
-    max_alias_count = max([alias['count'] for alias
-                           in TargetName.objects.values('target_id').annotate(count=Count('target_id'))])
+    aliases = TargetName.objects.filter(target__in=qs_pk).values('target_id').annotate(count=Count('target_id'))
+    max_alias_count = 0
+    if aliases:
+        max_alias_count = max([alias['count'] for alias in aliases])
     all_fields = target_fields + target_extra_fields + [f'name{index+1}' for index in range(1, max_alias_count+1)]
     for key in ['id', 'targetlist', 'dataproduct', 'observationrecord', 'reduceddatum', 'aliases', 'targetextra']:
         all_fields.remove(key)


### PR DESCRIPTION
…tests

Addresses #265.

When exporting targets, the code used the largest number of aliases for a single target in order to construct the headers for the exported CSV--it needed to append a name column for each extra alias. However, there were two issues with this:

- When there were no aliases in the result set, an exception was thrown.
- The code was checking the number of aliases for every target, rather than just the filtered ones.

This PR addresses both of those issues and includes additional tests, where the target export functionality was previously untested.