### PR TITLE
Fix/tns harvester message

### DIFF
--- a/docs/customization/customsettings.md
+++ b/docs/customization/customsettings.md
@@ -5,6 +5,21 @@ The following is a list of TOM Specific settings to be added/edited in your
 project's `settings.py`. For explanations of Django specific settings, see the
 [official documentation](https://docs.djangoproject.com/en/2.1/ref/settings/).
 
+
+### [ALERT_CREDENTIALS](#alert_credentials)
+
+Default: 
+
+    {
+        'TNS': {
+            'api_key': ''
+        }
+    }
+
+Credentials for any brokers that require them. At the moment, the only built-in TOM Toolkit broker module that 
+requires credentials is the TNS.
+
+
 ### [AUTH_STRATEGY](#auth_strategy)
 
 Default: 'READ_ONLY'
@@ -15,13 +30,27 @@ anything. A value of **LOCKED** requires all users to login before viewing any
 page. Use the [**OPEN_URLS**](#open_urls) setting for adding exemptions.
 
 
+### [DATA_PROCESSORS](#data_processors)
+
+Default:
+
+    {
+        'photometry': 'tom_dataproducts.processors.photometry_processor.PhotometryProcessor',
+        'spectroscopy': 'tom_dataproducts.processors.spectroscopy_processor.SpectroscopyProcessor',
+    }
+
+The `DATA_PROCESSORS` dict specifies the subclasses of `DataProcessor` that should be used for processing the 
+corresponding `data_type`s.
+
 ### [DATA_PRODUCT_TYPES](#data_types)
 
 Default:
 
     {
         'spectroscopy': ('spectroscopy', 'Spectroscopy'),
-        'photometry': ('photometry', 'Photometry')
+        'photometry': ('photometry', 'Photometry'),
+        'spectroscopy': ('spectroscopy', 'Spectroscopy'),
+        'image_file': ('image_file', 'Image File')
     }
 
 A list of machine readable, human readable tuples which determine the choices
@@ -92,11 +121,21 @@ With an [**AUTH_STRATEGY**](#auth_strategy) value of **LOCKED**, urls in this li
 visible to unauthenticated users. You might add the homepage ('/'), for example.
 
 
+### [TARGET_PERMISSIONS_ONLY](#target_permissions_only)
+
+Default: True
+
+This settings determines the permissions strategy of the TOM. When set to True, authorization permissions will be set 
+on Targets and cascade from there--that is, a group that can see a Target can see all ObservationRecords and Data 
+associated with the Target. When set to False, permissions can be set for a group at the Target level, the 
+ObservationRecord level, or the DataProduct level.
+
+
 ### [TARGET_TYPE](#target_type)
 
 Default: No default
 
-Can be either **SIDEREAL** or **NON_SIDEREAL**. This settings determines the
+Can be either **SIDEREAL** or **NON_SIDEREAL**. This setting determines the
 default target type for your TOM. TOMs can still create and work with targets of
 both types even after this option is set, but setting it to one of the values will
 optimize the workflow for that target type.
@@ -109,7 +148,10 @@ Default:
     [
         'tom_alerts.brokers.mars.MARSBroker',
         'tom_alerts.brokers.lasair.LasairBroker',
-        'tom_alerts.brokers.scout.ScoutBroker'
+        'tom_alerts.brokers.scout.ScoutBroker',
+        'tom_alerts.brokers.tns.TNSBroker',
+        'tom_alerts.brokers.antares.ANTARESBroker',
+        'tom_alerts.brokers.gaia.GaiaBroker'
     ]
 
 A list of tom alert classes to make available to your TOM. If you have written or
@@ -125,6 +167,8 @@ Default:
     [
         'tom_observations.facilities.lco.LCOFacility',
         'tom_observations.facilities.gemini.GEMFacility',
+        'tom_observations.facilities.soar.SOARFacility',
+        'tom_observations.facilities.lt.LTFacility'
     ]
 
 A list of observation facility classes to make available to your TOM. If you have
@@ -147,3 +191,16 @@ Default:
 A list of TOM harverster classes to make available to your TOM. If you have
 written or downloaded additional harvester classes you would make them available
 here.
+
+
+### [TOM_LATEX_PROCESSORS](#tom_latex_processors)
+
+Default:
+
+    {
+        'ObservationGroup': 'tom_publications.processors.latex_processor.ObservationGroupLatexProcessor',
+        'TargetList': 'tom_publications.processors.target_list_latex_processor.TargetListLatexProcessor'
+    }
+
+A dictionary with the keys being TOM models classes and the values being the modules that should be used to generate 
+latex tables for those models.

--- a/tom_catalogs/harvesters/tns.py
+++ b/tom_catalogs/harvesters/tns.py
@@ -7,29 +7,39 @@ from collections import OrderedDict
 from django.conf import settings
 
 from tom_catalogs.harvester import AbstractHarvester
+from tom_common.exceptions import ImproperCredentialsException
+
+TNS_URL = 'https://wis-tns.weizmann.ac.il'
+
+try:
+    TNS_CREDENTIALS = settings.BROKER_CREDENTIALS['TNS']
+except (AttributeError, KeyError):
+    TNS_CREDENTIALS = {
+        'api_key': ''
+    }
 
 
 def get(term):
-    api_key = settings.BROKER_CREDENTIALS['TNS_APIKEY']
-    url = "https://wis-tns.weizmann.ac.il/api/get"
+    # url = "https://wis-tns.weizmann.ac.il/api/get"
 
-    try:
-        get_url = url + '/object'
+    get_url = TNS_URL + '/api/get/object'
 
-        # change term to json format
-        json_list = [("objname", term)]
-        json_file = OrderedDict(json_list)
+    # change term to json format
+    json_list = [("objname", term)]
+    json_file = OrderedDict(json_list)
 
-        # construct the list of (key,value) pairs
-        get_data = [('api_key', (None, api_key)),
-                    ('data', (None, json.dumps(json_file)))]
+    # construct the list of (key,value) pairs
+    get_data = [('api_key', (None, TNS_CREDENTIALS['api_key'])),
+                ('data', (None, json.dumps(json_file)))]
 
-        response = requests.post(get_url, files=get_data)
-        response = json.loads(response.text)['data']['reply']
-        return response
+    response = requests.post(get_url, files=get_data)
+    response_data = json.loads(response.text)
+    print(response_data)
 
-    except Exception as e:
-        return [None, 'Error message : \n' + str(e)]
+    if 400 <= response_data.get('id_code') <= 403:
+        raise ImproperCredentialsException('TNS: ' + str(response_data.get('id_message')))
+
+    return response_data['data']['reply']
 
 
 class TNSHarvester(AbstractHarvester):

--- a/tom_catalogs/harvesters/tns.py
+++ b/tom_catalogs/harvesters/tns.py
@@ -34,7 +34,6 @@ def get(term):
 
     response = requests.post(get_url, files=get_data)
     response_data = json.loads(response.text)
-    print(response_data)
 
     if 400 <= response_data.get('id_code') <= 403:
         raise ImproperCredentialsException('TNS: ' + str(response_data.get('id_message')))

--- a/tom_catalogs/harvesters/tns.py
+++ b/tom_catalogs/harvesters/tns.py
@@ -12,7 +12,7 @@ from tom_common.exceptions import ImproperCredentialsException
 TNS_URL = 'https://wis-tns.weizmann.ac.il'
 
 try:
-    TNS_CREDENTIALS = settings.BROKER_CREDENTIALS['TNS']
+    TNS_CREDENTIALS = settings.ALERT_CREDENTIALS['TNS']
 except (AttributeError, KeyError):
     TNS_CREDENTIALS = {
         'api_key': ''

--- a/tom_catalogs/harvesters/tns.py
+++ b/tom_catalogs/harvesters/tns.py
@@ -1,5 +1,4 @@
 import json
-import os
 import requests
 
 from astropy import units as u

--- a/tom_common/middleware.py
+++ b/tom_common/middleware.py
@@ -19,8 +19,8 @@ class ExternalServiceMiddleware:
         if isinstance(exception, ImproperCredentialsException):
             msg = (
                     'There was a problem authenticating with {}. Please check you have the correct '
-                    'credentials entered into your FACILITIES setting. '
-                    'https://tomtoolkit.github.io/docs/customsettings#facilities '
+                    'credentials the corresponding settings variable. '
+                    'https://tomtoolkit.github.io/docs/customsettings '
                 ).format(
                 str(exception)
             )

--- a/tom_common/middleware.py
+++ b/tom_common/middleware.py
@@ -18,9 +18,9 @@ class ExternalServiceMiddleware:
     def process_exception(self, request, exception):
         if isinstance(exception, ImproperCredentialsException):
             msg = (
-                    'There was a problem authenticating with {}. Please check you have the correct '
-                    'credentials the corresponding settings variable. '
-                    'https://tomtoolkit.github.io/docs/customsettings '
+                    'There was a problem authenticating with {}. Please check that you have the correct '
+                    'credentials in the corresponding settings variable. '
+                    'https://tom-toolkit.readthedocs.io/en/stable/customization/customsettings.html '
                 ).format(
                 str(exception)
             )

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -246,9 +246,14 @@ TOM_ALERT_CLASSES = [
     'tom_alerts.brokers.lasair.LasairBroker',
     'tom_alerts.brokers.scout.ScoutBroker',
     'tom_alerts.brokers.tns.TNSBroker',
+    'tom_alerts.brokers.antares.ANTARESBroker',
+    'tom_alerts.brokers.gaia.GaiaBroker'
 ]
 
-BROKER_CREDENTIALS = {
+ALERT_CREDENTIALS = {
+    'TNS': {
+        'api_key': ''
+    }
 }
 
 # Define extra target fields here. Types can be any of "number", "string", "boolean" or "datetime"


### PR DESCRIPTION
This addresses #218 finally. Makes the api_key acquisition a little more bulletproof and throws the proper exception to ensure more attractive exception handling.

Also added a corresponding task to document the use of the ImproperCredentialsException.

@jfrostburke, can you test the actual functionality of the harvester? I just tested the errors--I don't have a TNS API key.