### PR TITLE
Feature/ui fixes

### DIFF
--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -106,7 +106,6 @@ class LCOBaseForm(forms.Form):
 
     def _get_instruments(self):
         cached_instruments = cache.get('lco_instruments')
-        cached_instruments = None
 
         if not cached_instruments:
             response = make_request(

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from datetime import datetime, timedelta
 import requests
 
@@ -112,7 +113,7 @@ class LCOBaseForm(forms.Form):
                 PORTAL_URL + '/api/instruments/',
                 headers={'Authorization': 'Token {0}'.format(LCO_SETTINGS['api_key'])}
             )
-            cached_instruments = {k: v for k, v in response.json().items() if 'SOAR' not in k}
+            cached_instruments = OrderedDict((k, v) for k, v in response.json().items() if 'SOAR' not in k)
             cache.set('lco_instruments', cached_instruments)
 
         return cached_instruments

--- a/tom_observations/static/tom_observations/css/main.css
+++ b/tom_observations/static/tom_observations/css/main.css
@@ -18,3 +18,7 @@
 span.featured {
   pointer-events: none;
 }
+
+div.observation-form {
+  padding: 20px 0px;
+}

--- a/tom_observations/static/tom_observations/css/main.css
+++ b/tom_observations/static/tom_observations/css/main.css
@@ -20,5 +20,5 @@ span.featured {
 }
 
 div.observation-form {
-  padding: 20px 0px;
+  padding-top: 20px;
 }

--- a/tom_observations/templates/tom_observations/observation_form.html
+++ b/tom_observations/templates/tom_observations/observation_form.html
@@ -3,6 +3,7 @@
 {% block title %}Submit Observation{% endblock %}
 {% block additional_css %}
 <link rel="stylesheet" href="{% static 'tom_common/css/main.css' %}">
+<link rel="stylesheet" href="{% static 'tom_observations/css/main.css' %}">
 {% endblock %}
 {% block content %}
 {{ form|as_crispy_errors }}
@@ -34,7 +35,7 @@
             </li>
         {% endfor %}
         </ul>
-        <div class="tab-content">
+        <div class="tab-content observation-form">
         {% for observation_type, observation_form in observation_type_choices %}
             <div class="tab-pane {% if observation_type == active or not active and forloop.first %}active{% endif %}" id="{{ observation_type }}">
                 {% crispy observation_form %}


### PR DESCRIPTION
This PR addresses the following items from the TOM UI story:

- Makes comments hidden unless authenticated
- (bonus) Only shows comments for targets the user has permission to view
- Sorts instrument and filter lists in LCO observation forms
- Adds the spectroscopic sequence form
- (bonus) Fixes padding on observation forms