### PR TITLE
Fix/cadence parameters

### DIFF
--- a/tom_observations/cadence.py
+++ b/tom_observations/cadence.py
@@ -67,7 +67,7 @@ class BaseCadenceForm(CadenceForm):
         required=True,
         help_text='Frequency of observations, in hours'
     )
-    cadence_fields = ['cadence_frequency']
+    cadence_fields = set(['cadence_frequency'])
 
     def cadence_layout(self):
         return Layout(

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -476,7 +476,7 @@ class LCOPhotometricSequenceForm(LCOBaseObservationForm):
 
         # Add fields for each available filter as specified in the filters property
         for filter_name in self.filters:
-            self.fields[filter_name] = FilterField(label=filter_name, required=False, min_value=0)
+            self.fields[filter_name] = FilterField(label=filter_name, required=False)
 
         # Massage cadence form to be SNEx-styled
         self.fields['cadence_strategy'] = forms.ChoiceField(

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -530,7 +530,7 @@ class LCOPhotometricSequenceForm(LCOBaseObservationForm):
         """
         cleaned_data = super().clean()
         now = datetime.now()
-        cleaned_data['start'] = datetime.strftime(datetime.now(), '%Y-%m-%dT%H:%M:%S')
+        cleaned_data['start'] = datetime.strftime(now, '%Y-%m-%dT%H:%M:%S')
         cleaned_data['end'] = datetime.strftime(now + timedelta(hours=cleaned_data['cadence_frequency']),
                                                 '%Y-%m-%dT%H:%M:%S')
 

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -168,7 +168,7 @@ class LCOBaseObservationForm(BaseRoboticObservationForm, LCOBaseForm):
     exposure_time = forms.FloatField(min_value=0.1,
                                      widget=forms.TextInput(attrs={'placeholder': 'Seconds'}),
                                      help_text=exposure_time_help)
-    max_airmass = forms.FloatField(help_text=max_airmass_help)
+    max_airmass = forms.FloatField(help_text=max_airmass_help, min_value=0)
     min_lunar_distance = forms.IntegerField(min_value=0, label='Minimum Lunar Distance', required=False)
     period = forms.FloatField(required=False)
     jitter = forms.FloatField(required=False)
@@ -476,7 +476,7 @@ class LCOPhotometricSequenceForm(LCOBaseObservationForm):
 
         # Add fields for each available filter as specified in the filters property
         for filter_name in self.filters:
-            self.fields[filter_name] = FilterField(label=filter_name, required=False)
+            self.fields[filter_name] = FilterField(label=filter_name, required=False, min_value=0)
 
         # Massage cadence form to be SNEx-styled
         self.fields['cadence_strategy'] = forms.ChoiceField(
@@ -751,6 +751,7 @@ class LCOFacility(BaseRoboticObservationFacility):
     """
 
     name = 'LCO'
+    # TODO: make the keys the display values instead
     observation_forms = {
         'IMAGING': LCOImagingObservationForm,
         'SPECTRA': LCOSpectroscopyObservationForm,

--- a/tom_observations/models.py
+++ b/tom_observations/models.py
@@ -157,7 +157,7 @@ class DynamicCadence(models.Model):
     modified = models.DateTimeField(auto_now=True, help_text='The time which this DynamicCadence was modified.')
 
     def __str__(self):
-        return self.name
+        return f'{self.cadence_strategy} with parameters {self.cadence_parameters}'
 
 
 class ObservationTemplate(models.Model):

--- a/tom_observations/templates/tom_observations/partials/observing_buttons.html
+++ b/tom_observations/templates/tom_observations/partials/observing_buttons.html
@@ -1,3 +1,3 @@
 {% for facility in facilities %}
-<a href="{% url 'tom_observations:create' facility=facility %}?target_id={{ target.id }}" class="btn  btn-outline-primary">{{ facility }}</a>
+<a href="{% url 'tom_observations:create' facility=facility %}?target_id={{ target.id }}" class="btn btn-outline-primary">{{ facility }}</a>
 {% endfor %}

--- a/tom_observations/widgets.py
+++ b/tom_observations/widgets.py
@@ -5,7 +5,6 @@ from django.core.validators import MinValueValidator
 class FilterConfigurationWidget(forms.widgets.MultiWidget):
 
     def __init__(self, attrs=None):
-        print(attrs)
         if not attrs:
             attrs = {}
         _default_attrs = {'class': 'form-control col-md-3', 'style': 'margin-right: 10px; display: inline-block'}
@@ -26,10 +25,7 @@ class FilterField(forms.MultiValueField):
     widget = FilterConfigurationWidget
 
     def __init__(self, *args, **kwargs):
-        min_value = kwargs.pop('min_value', 0)
-        fields = (forms.IntegerField(validators=[MinValueValidator(min_value)]),
-                  forms.IntegerField(validators=[MinValueValidator(min_value)]),
-                  forms.IntegerField(validators=[MinValueValidator(min_value)]))
+        fields = (forms.IntegerField(), forms.IntegerField(), forms.IntegerField())
         super().__init__(fields=fields, *args, **kwargs)
 
     def compress(self, data_list):

--- a/tom_observations/widgets.py
+++ b/tom_observations/widgets.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.core.validators import MinValueValidator
 
 
 class FilterConfigurationWidget(forms.widgets.MultiWidget):

--- a/tom_observations/widgets.py
+++ b/tom_observations/widgets.py
@@ -26,7 +26,7 @@ class FilterField(forms.MultiValueField):
 
     def __init__(self, *args, **kwargs):
         fields = (forms.IntegerField(), forms.IntegerField(), forms.IntegerField())
-        super().__init__(fields=fields, *args, **kwargs)
+        super().__init__(fields, *args, **kwargs)
 
     def compress(self, data_list):
         return data_list

--- a/tom_observations/widgets.py
+++ b/tom_observations/widgets.py
@@ -1,9 +1,11 @@
 from django import forms
+from django.core.validators import MinValueValidator
 
 
 class FilterConfigurationWidget(forms.widgets.MultiWidget):
 
     def __init__(self, attrs=None):
+        print(attrs)
         if not attrs:
             attrs = {}
         _default_attrs = {'class': 'form-control col-md-3', 'style': 'margin-right: 10px; display: inline-block'}
@@ -24,8 +26,11 @@ class FilterField(forms.MultiValueField):
     widget = FilterConfigurationWidget
 
     def __init__(self, *args, **kwargs):
-        fields = (forms.IntegerField(), forms.IntegerField(), forms.IntegerField())
-        super().__init__(fields, *args, **kwargs)
+        min_value = kwargs.pop('min_value', 0)
+        fields = (forms.IntegerField(validators=[MinValueValidator(min_value)]),
+                  forms.IntegerField(validators=[MinValueValidator(min_value)]),
+                  forms.IntegerField(validators=[MinValueValidator(min_value)]))
+        super().__init__(fields=fields, *args, **kwargs)
 
     def compress(self, data_list):
         return data_list


### PR DESCRIPTION
The branch name is officially a misnomer, as the problems with NRES cadencing were largely in the calibration-tom. The fixes here are as follows:

- In `tom_observations/cadence.py`, made the `cadence_fields` a `set` so that fields won't inadvertently be saved multiple times.
- In `tom_observations/facilities/lco.py`, added a `min_value` to `max_airmass` and removed some redundancy from date validation in the `PhotometricSequenceForm`.
- In `tom_observations/models.py`, fixed the `__str__` representation.
- In `tom_observations/templates/tom_observations/partials/observing_buttons.html`, removed a superfluous space.