### PR TITLE
Feature/add muscat support

### DIFF
--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -472,9 +472,10 @@ class LCOMuscatImagingObservationForm(LCOBaseObservationForm):
 
     @staticmethod
     def instrument_choices():
-        return sorted(set([
-            (k, v['name']) for k, v in LCOMuscatImagingObservationForm._get_muscat_instrument().items()]),
-            key=lambda inst: inst[1])
+        return sorted([
+            (k, v['name']) for k, v in LCOMuscatImagingObservationForm._get_muscat_instrument().items()],
+            key=lambda inst: inst[1]
+        )
 
     @staticmethod
     def mode_choices(mode_type):

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -94,7 +94,7 @@ static_cadencing_help = """
 """
 
 muscat_exposure_mode_help = """
-    Synchronous syncs the start time of exposures on all 4 cameras while asynchronous takes 
+    Synchronous syncs the start time of exposures on all 4 cameras while asynchronous takes
     exposures as quickly as possible on each camera.
 """
 

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -86,6 +86,7 @@ max_airmass_help = """
 """
 
 static_cadencing_help = """
+    Static cadence parameters. Leave blank if no cadencing is desired.
     For information on static cadencing with LCO,
     <a href="https://lco.global/documentation/">
         check the Observation Portal getting started guide, starting on page 18.
@@ -205,8 +206,7 @@ class LCOBaseObservationForm(BaseRoboticObservationForm, LCOBaseForm):
                 css_class='form-row',
             ),
             Div(
-                HTML(f'''<br/><p>Static cadence parameters. Leave blank if no cadencing is desired.
-                         {static_cadencing_help} </p>'''),
+                HTML(f'''<br/><p>{static_cadencing_help}</p>'''),
             ),
             Div(
                 Div(
@@ -449,8 +449,7 @@ class LCOMuscatImagingObservationForm(LCOBaseObservationForm):
                 css_class='form-row',
             ),
             Div(
-                HTML(f'''<br/><p>Static cadence parameters. Leave blank if no cadencing is desired.
-                         {static_cadencing_help} </p>'''),
+                HTML(f'''<br/><p>{static_cadencing_help}</p>'''),
             ),
             Div(
                 Div(

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -3,7 +3,7 @@ import requests
 
 from astropy import units as u
 from crispy_forms.bootstrap import AppendedText, PrependedText
-from crispy_forms.layout import Column, Div, HTML, Layout, Row, MultiWidgetField
+from crispy_forms.layout import Column, Div, HTML, Layout, Row, MultiWidgetField, Fieldset
 from dateutil.parser import parse
 from django import forms
 from django.conf import settings
@@ -49,7 +49,7 @@ ipp_value_help = """
         Value between 0.5 to 2.0.
         <a href="https://lco.global/documents/20/the_new_priority_factor.pdf">
             More information about Intra Proprosal Priority (IPP).
-        </a>.
+        </a>
 """
 
 observation_mode_help = """
@@ -91,6 +91,11 @@ static_cadencing_help = """
     <a href="https://lco.global/documentation/">
         check the Observation Portal getting started guide, starting on page 18.
     </a>
+"""
+
+muscat_exposure_mode_help = """
+    Synchronous syncs the start time of exposures on all 4 cameras while asynchronous takes 
+    exposures as quickly as possible on each camera.
 """
 
 
@@ -415,10 +420,10 @@ class LCOMuscatImagingObservationForm(LCOBaseObservationForm):
     The LCOMuscatImagingObservationForm allows the selection of parameter for observing using LCO's Muscat imaging
     instrument. More information can be found here: https://lco.global/observatory/instruments/muscat3/
     """
-    exposure_time_g = forms.FloatField(min_value=0)
-    exposure_time_r = forms.FloatField(min_value=0)
-    exposure_time_i = forms.FloatField(min_value=0)
-    exposure_time_z = forms.FloatField(min_value=0)
+    exposure_time_g = forms.FloatField(min_value=0, label='g')
+    exposure_time_r = forms.FloatField(min_value=0, label='r')
+    exposure_time_i = forms.FloatField(min_value=0, label='i')
+    exposure_time_z = forms.FloatField(min_value=0, label='z')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -426,42 +431,102 @@ class LCOMuscatImagingObservationForm(LCOBaseObservationForm):
         self.fields.pop('filter', None)
         self.fields.pop('exposure_time', None)
         self.fields['guider_mode'] = forms.ChoiceField(choices=self.mode_choices('guiding'))
-        self.fields['exposure_mode'] = forms.ChoiceField(choices=self.mode_choices('exposure'))
-        self.fields['diffuser_g_position'] = forms.ChoiceField(choices=self.diffuser_position_choices(channel='g'))
-        self.fields['diffuser_r_position'] = forms.ChoiceField(choices=self.diffuser_position_choices(channel='r'))
-        self.fields['diffuser_i_position'] = forms.ChoiceField(choices=self.diffuser_position_choices(channel='i'))
-        self.fields['diffuser_z_position'] = forms.ChoiceField(choices=self.diffuser_position_choices(channel='z'))
+        self.fields['exposure_mode'] = forms.ChoiceField(
+            choices=self.mode_choices('exposure'),
+            help_text=muscat_exposure_mode_help
+        )
+        self.fields['diffuser_g_position'] = forms.ChoiceField(
+            choices=self.diffuser_position_choices(channel='g'),
+            label='g'
+        )
+        self.fields['diffuser_r_position'] = forms.ChoiceField(
+            choices=self.diffuser_position_choices(channel='r'),
+            label='r'
+        )
+        self.fields['diffuser_i_position'] = forms.ChoiceField(
+            choices=self.diffuser_position_choices(channel='i'),
+            label='i'
+        )
+        self.fields['diffuser_z_position'] = forms.ChoiceField(
+            choices=self.diffuser_position_choices(channel='z'),
+            label='z'
+        )
 
     def layout(self):
         return Div(
             Div(
                 Div(
-                    'name', 'proposal', 'ipp_value', 'observation_mode', 'start', 'end', 'max_airmass',
-                    'min_lunar_distance',
+                    'name', 'proposal', 'ipp_value', 'observation_mode', 'start', 'end',
                     css_class='col'
                 ),
                 Div(
-                    'instrument_type', 'guider_mode', 'exposure_mode', 'exposure_count', 'exposure_time_g',
-                    'exposure_time_r', 'exposure_time_i', 'exposure_time_z', 'diffuser_g_position',
-                    'diffuser_r_position', 'diffuser_i_position', 'diffuser_z_position',
+                    'instrument_type', 'guider_mode', 'exposure_mode', 'exposure_count', 'max_airmass',
+                    'min_lunar_distance',
                     css_class='col'
                 ),
                 css_class='form-row',
             ),
-            Div(
-                HTML(f'''<br/><p>{static_cadencing_help}</p>'''),
-            ),
-            Div(
+            Fieldset(
+                'Diffuser Positions',
+                HTML('''<p>Select the diffuser position for each channel.</p>'''),
                 Div(
-                    'period',
-                    css_class='col'
-                ),
-                Div(
-                    'jitter',
-                    css_class='col'
-                ),
-                css_class='form-row'
+                    Div(
+                        'diffuser_g_position',
+                        css_class='col'
+                    ),
+                    Div(
+                        'diffuser_r_position',
+                        css_class='col'
+                    ),
+                    Div(
+                        'diffuser_i_position',
+                        css_class='col'
+                    ),
+                    Div(
+                        'diffuser_z_position',
+                        css_class='col'
+                    ),
+                    css_class='form-row'
+                )
             ),
+            Fieldset(
+                'Exposure Times',
+                HTML('''<p>Set an exposure time for each channel.</p>'''),
+                Div(
+                    Div(
+                        'exposure_time_g',
+                        css_class='col'
+                    ),
+                    Div(
+                        'exposure_time_r',
+                        css_class='col'
+                    ),
+                    Div(
+                        'exposure_time_i',
+                        css_class='col'
+                    ),
+                    Div(
+                        'exposure_time_z',
+                        css_class='col'
+                    ),
+                    css_class='form-row'
+                )
+            ),
+            Fieldset(
+                'Cadence',
+                HTML(f'''<p>{static_cadencing_help}</p>'''),
+                Div(
+                    Div(
+                        'period',
+                        css_class='col'
+                    ),
+                    Div(
+                        'jitter',
+                        css_class='col'
+                    ),
+                    css_class='form-row'
+                )
+            )
         )
 
     @staticmethod

--- a/tom_observations/tests/facilities/test_lco.py
+++ b/tom_observations/tests/facilities/test_lco.py
@@ -9,7 +9,7 @@ from tom_common.exceptions import ImproperCredentialsException
 from tom_observations.facilities.lco import make_request
 from tom_observations.facilities.lco import LCOBaseForm, LCOBaseObservationForm, LCOImagingObservationForm
 from tom_observations.facilities.lco import LCOPhotometricSequenceForm, LCOSpectroscopicSequenceForm
-from tom_observations.facilities.lco import LCOSpectroscopyObservationForm
+from tom_observations.facilities.lco import LCOSpectroscopyObservationForm, LCOMuscatImagingObservationForm
 from tom_observations.tests.factories import SiderealTargetFactory, NonSiderealTargetFactory
 
 
@@ -31,6 +31,16 @@ instrument_response = {
                 {'name': '100um Pinhole', 'code': '100um-Pinhole', 'schedulable': False, 'default': False},
             ]
         },
+        'modes': {
+            'guiding': {
+                'type': 'guiding',
+                'modes': [
+                    {'name': 'On', 'overhead': 0.0, 'code': 'ON'},
+                    {'name': 'Off', 'overhead': 0.0, 'code': 'OFF'},
+                ],
+                'default': 'ON'
+            }
+        }
     },
     'SOAR_GHTS_REDCAM': {
         'type': 'SPECTRA', 'class': '4m0', 'name': 'Goodman Spectrograph RedCam', 'optical_elements': {
@@ -41,8 +51,55 @@ instrument_response = {
                 {'name': '1.0 arcsec slit', 'code': 'slit_1.0as', 'schedulable': True, 'default': True}
             ]
         },
+    },
+    '2M0-SCICAM-MUSCAT': {
+        'type': 'IMAGE', 'class': '2m0', 'name': '2.0 meter Muscat',
+        'optical_elements': {
+            'diffuser_g_positions': [
+                {'name': 'In Beam', 'code': 'in', 'schedulable': True, 'default': True},
+                {'name': 'Out of Beam', 'code': 'out', 'schedulable': True, 'default': True}
+            ],
+            'diffuser_r_positions': [
+                {'name': 'In Beam', 'code': 'in', 'schedulable': True, 'default': False},
+                {'name': 'Out of Beam', 'code': 'out', 'schedulable': True, 'default': True}
+            ],
+            'diffuser_i_positions': [
+                {'name': 'In Beam', 'code': 'in', 'schedulable': True, 'default': False},
+                {'name': 'Out of Beam', 'code': 'out', 'schedulable': True, 'default': True}
+            ],
+            'diffuser_z_positions': [
+                {'name': 'In Beam', 'code': 'in', 'schedulable': True, 'default': False},
+                {'name': 'Out of Beam', 'code': 'out', 'schedulable': True, 'default': True}
+            ]
+        },
+        'modes': {
+            'guiding': {
+                'type': 'guiding',
+                'modes': [
+                    {'name': 'On', 'overhead': 0.0, 'code': 'ON'},
+                    {'name': 'Muscat G Guiding', 'overhead': 0.0, 'code': 'MUSCAT_G'},
+                ],
+                'default': 'ON'
+            },
+            'exposure': {
+                'type': 'exposure',
+                'modes': [
+                    {'name': 'Muscat Synchronous Exposure Mode', 'overhead': 0.0, 'code': 'SYNCHRONOUS'},
+                    {'name': 'Muscat Asynchronous Exposure Mode', 'overhead': 0.0, 'code': 'ASYNCHRONOUS'}
+                ],
+                'default': 'SYNCHRONOUS'
+            }
+        }
     }
 }
+
+
+def generate_lco_instrument_choices():
+    return {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+
+
+def generate_lco_proposal_choices():
+    return [('sampleproposal', 'Sample Proposal')]
 
 
 class TestMakeRequest(TestCase):
@@ -93,16 +150,17 @@ class TestLCOBaseForm(TestCase):
 
     @patch('tom_observations.facilities.lco.LCOBaseForm._get_instruments')
     def test_instrument_choices(self, mock_get_instruments):
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
 
         inst_choices = LCOBaseForm.instrument_choices()
         self.assertIn(('2M0-FLOYDS-SCICAM', '2.0 meter FLOYDS'), inst_choices)
         self.assertIn(('0M4-SCICAM-SBIG', '0.4 meter SBIG'), inst_choices)
-        self.assertEqual(len(inst_choices), 2)
+        self.assertIn(('2M0-SCICAM-MUSCAT', '2.0 meter Muscat'), inst_choices)
+        self.assertEqual(len(inst_choices), 3)
 
     @patch('tom_observations.facilities.lco.LCOBaseForm._get_instruments')
     def test_filter_choices(self, mock_get_instruments):
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
 
         filter_choices = LCOBaseForm.filter_choices()
         for expected in [('opaque', 'Opaque'), ('100um-Pinhole', '100um Pinhole'), ('slit_6.0as', '6.0 arcsec slit')]:
@@ -144,7 +202,7 @@ class TestLCOBaseObservationForm(TestCase):
             (f['code'], f['name']) for ins in instrument_response.values() for f in
             ins['optical_elements'].get('filters', []) + ins['optical_elements'].get('slits', [])
         ])
-        self.proposal_choices = [('sampleproposal', 'Sample Proposal')]
+        self.proposal_choices = generate_lco_proposal_choices()
 
     def test_validate_at_facility(self, mock_validate, mock_insts, mock_filters, mock_proposals):
         pass
@@ -266,7 +324,7 @@ class TestLCOBaseObservationForm(TestCase):
     @patch('tom_observations.facilities.lco.LCOBaseForm._get_instruments')
     def test_build_location(self, mock_get_instruments, mock_validate, mock_insts, mock_filters, mock_proposals):
         """Test _build_location method."""
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
         mock_validate.return_value = []
         mock_insts.return_value = self.instrument_choices
         mock_filters.return_value = self.filter_choices
@@ -321,16 +379,17 @@ class TestLCOBaseObservationForm(TestCase):
 class TestLCOImagingObservationForm(TestCase):
     def test_instrument_choices(self, mock_get_instruments):
         """Test LCOImagingObservationForm._instrument_choices."""
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
 
         inst_choices = LCOImagingObservationForm.instrument_choices()
         self.assertIn(('0M4-SCICAM-SBIG', '0.4 meter SBIG'), inst_choices)
         self.assertNotIn(('2M0-FLOYDS-SCICAM', '2.0 meter FLOYDS'), inst_choices)
+        self.assertNotIn(('2M0-SCICAM-MUSCAT', '2.0 meter Muscat'), inst_choices)
         self.assertEqual(len(inst_choices), 1)
 
     def test_filter_choices(self, mock_get_instruments):
         """Test LCOImagingObservationForm._filter_choices."""
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
 
         filter_choices = LCOImagingObservationForm.filter_choices()
         for expected in [('opaque', 'Opaque'), ('100um-Pinhole', '100um Pinhole')]:
@@ -341,11 +400,99 @@ class TestLCOImagingObservationForm(TestCase):
         self.assertEqual(len(filter_choices), 2)
 
 
+@patch('tom_observations.facilities.lco.LCOMuscatImagingObservationForm.validate_at_facility')
+@patch('tom_observations.facilities.lco.LCOMuscatImagingObservationForm.filter_choices')
+@patch('tom_observations.facilities.lco.LCOMuscatImagingObservationForm.proposal_choices')
+@patch('tom_observations.facilities.lco.LCOMuscatImagingObservationForm._get_instruments')
+class TestLCOMuscatImagingObservationForm(TestCase):
+
+    def setUp(self):
+        self.st = SiderealTargetFactory.create()
+        self.valid_form_data = {
+            'name': 'test', 'facility': 'LCO', 'target_id': self.st.id, 'ipp_value': 0.5, 'start': '2020-11-03',
+            'end': '2020-11-04', 'exposure_count': 1, 'exposure_time_g': 30, 'exposure_time_r': 40,
+            'exposure_time_i': 50, 'exposure_time_z': 60, 'diffuser_g_position': 'out', 'diffuser_r_position': 'out',
+            'diffuser_i_position': 'in', 'diffuser_z_position': 'in', 'observation_mode': 'NORMAL',
+            'guider_mode': 'MUSCAT_G', 'exposure_mode': 'SYNCHRONOUS', 'proposal': 'sampleproposal',
+            'instrument_type': '2M0-SCICAM-MUSCAT', 'max_airmass': 3.0
+        }
+
+    def test_instrument_choices(self, mock_get_instruments, mock_get_proposals, mock_get_filters, mock_validate):
+        """Test LCOMuscatImagingObservationForm._instrument_choices."""
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
+        inst_choices = LCOMuscatImagingObservationForm.instrument_choices()
+        self.assertIn(('2M0-SCICAM-MUSCAT', '2.0 meter Muscat'), inst_choices)
+        self.assertEqual(len(inst_choices), 1)
+
+    def test_diffuser_choices(self, mock_get_instruments, mock_get_proposals, mock_get_filters, mock_validate):
+        """Test LCOMuscatImagingObservationForm.diffuser_position_choices."""
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
+        for channel in ['g', 'r', 'i', 'z']:
+            with self.subTest(channel=channel):
+                diffuser_choices = LCOMuscatImagingObservationForm.diffuser_position_choices(channel=channel)
+                self.assertIn(('in', 'In Beam'), diffuser_choices)
+                self.assertIn(('out', 'Out of Beam'), diffuser_choices)
+                self.assertTrue(len(diffuser_choices), 2)
+
+    def test_exposure_mode_choices(self, mock_get_instruments, mock_get_proposals, mock_get_filters, mock_validate):
+        """Test LCOMuscatImagingObservationForm.mode_choices for exposure modes."""
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
+        exposure_mode_choices = LCOMuscatImagingObservationForm.mode_choices('exposure')
+        self.assertIn(('SYNCHRONOUS', 'Muscat Synchronous Exposure Mode'), exposure_mode_choices)
+        self.assertIn(('ASYNCHRONOUS', 'Muscat Asynchronous Exposure Mode'), exposure_mode_choices)
+        self.assertEqual(len(exposure_mode_choices), 2)
+
+    def test_guide_mode_choices(self, mock_get_instruments, mock_get_proposals, mock_get_filters, mock_validate):
+        """Test LCOMuscatImagingObservationForm.mode_choices for guiding modes."""
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
+        guide_mode_choices = LCOMuscatImagingObservationForm.mode_choices('guiding')
+        self.assertIn(('MUSCAT_G', 'Muscat G Guiding'), guide_mode_choices)
+        self.assertIn(('ON', 'On'), guide_mode_choices)
+        self.assertEqual(len(guide_mode_choices), 2)
+
+    def test_build_instrument_config(self, mock_get_instruments, mock_get_proposals, mock_get_filters, mock_validate):
+        """Test LCOMuscatImagingObservationForm._build_instrument_config."""
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
+        mock_get_proposals.return_value = generate_lco_proposal_choices()
+        form = LCOMuscatImagingObservationForm(self.valid_form_data)
+        self.assertTrue(form.is_valid())
+        instrument_config = form._build_instrument_config()
+        expected_exposure_time = max(
+            self.valid_form_data['exposure_time_g'],
+            self.valid_form_data['exposure_time_r'],
+            self.valid_form_data['exposure_time_i'],
+            self.valid_form_data['exposure_time_z']
+        )
+        self.assertEqual(expected_exposure_time, instrument_config[0]['exposure_time'])
+        self.assertDictEqual({
+            'exposure_mode': self.valid_form_data['exposure_mode'],
+            'exposure_time_g': self.valid_form_data['exposure_time_g'],
+            'exposure_time_r': self.valid_form_data['exposure_time_r'],
+            'exposure_time_i': self.valid_form_data['exposure_time_i'],
+            'exposure_time_z': self.valid_form_data['exposure_time_z']
+        }, instrument_config[0]['extra_params'])
+        self.assertDictEqual({
+            'diffuser_g_position': 'out',
+            'diffuser_r_position': 'out',
+            'diffuser_i_position': 'in',
+            'diffuser_z_position': 'in'
+        }, instrument_config[0]['optical_elements'])
+
+    def test_build_guiding_config(self, mock_get_instruments, mock_get_proposals, mock_get_filters, mock_validate):
+        """Test LCOMuscatImagingObservationForm._build_guiding_config."""
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
+        mock_get_proposals.return_value = generate_lco_proposal_choices()
+        form = LCOMuscatImagingObservationForm(self.valid_form_data)
+        self.assertTrue(form.is_valid())
+        guiding_config = form._build_guiding_config()
+        self.assertDictEqual({'mode': 'MUSCAT_G', 'optional': True},  guiding_config)
+
+
 class TestLCOSpectroscopyObservationForm(TestCase):
     @patch('tom_observations.facilities.lco.LCOSpectroscopyObservationForm._get_instruments')
     def test_instrument_choices(self, mock_get_instruments):
         """Test LCOSpectroscopyObservationForm._instrument_choices."""
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
 
         inst_choices = LCOSpectroscopyObservationForm.instrument_choices()
         self.assertIn(('2M0-FLOYDS-SCICAM', '2.0 meter FLOYDS'), inst_choices)
@@ -355,7 +502,7 @@ class TestLCOSpectroscopyObservationForm(TestCase):
     @patch('tom_observations.facilities.lco.LCOSpectroscopyObservationForm._get_instruments')
     def test_filter_choices(self, mock_get_instruments):
         """Test LCOSpectroscopyObservationForm._filter_choices."""
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
 
         filter_choices = LCOSpectroscopyObservationForm.filter_choices()
         for expected in [('slit_6.0as', '6.0 arcsec slit'), ('slit_1.6as', '1.6 arcsec slit'),
@@ -376,12 +523,12 @@ class TestLCOSpectroscopyObservationForm(TestCase):
             (f['code'], f['name']) for ins in instrument_response.values() for f in
             ins['optical_elements'].get('slits', [])
             ] + [('None', 'None')])
-        mock_proposals.return_value = [('sampleproposal', 'Sample Proposal')]
+        mock_proposals.return_value = generate_lco_proposal_choices()
 
         st = SiderealTargetFactory.create()
         valid_form_data = {
             'name': 'test', 'facility': 'LCO', 'target_id': st.id, 'ipp_value': 0.5, 'start': '2020-11-03',
-            'end': '2020-11-04', 'exposure_count': 1, 'exposure_time': 30.0, 'max_airmass': 3,
+            'end': '2020-11-04', 'exposure_count': 1, 'exposure_time': 30.0, 'max_airmass': 3.0,
             'min_lunar_distance': 20, 'observation_mode': 'NORMAL', 'proposal': 'sampleproposal',
             'filter': 'slit_2.0as', 'instrument_type': '2M0-FLOYDS-SCICAM', 'rotator_angle': 1.0
         }
@@ -427,12 +574,12 @@ class TestLCOPhotometricSequenceForm(TestCase):
             (f['code'], f['name']) for ins in instrument_response.values() for f in
             ins['optical_elements'].get('filters', []) + ins['optical_elements'].get('slits', [])
         ])
-        self.proposal_choices = [('sampleproposal', 'Sample Proposal')]
+        self.proposal_choices = generate_lco_proposal_choices()
 
     @patch('tom_observations.facilities.lco.LCOPhotometricSequenceForm._get_instruments')
     def test_instrument_choices(self, mock_get_instruments):
         """Test LCOPhotometricSequenceForm._instrument_choices."""
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
 
         inst_choices = LCOPhotometricSequenceForm.instrument_choices()
         self.assertIn(('0M4-SCICAM-SBIG', '0.4 meter SBIG'), inst_choices)
@@ -498,12 +645,12 @@ class TestLCOSpectroscopicSequenceForm(TestCase):
             (f['code'], f['name']) for ins in instrument_response.values() for f in
             ins['optical_elements'].get('filters', []) + ins['optical_elements'].get('slits', [])
         ])
-        self.proposal_choices = [('sampleproposal', 'Sample Proposal')]
+        self.proposal_choices = generate_lco_proposal_choices()
 
     @patch('tom_observations.facilities.lco.LCOSpectroscopicSequenceForm._get_instruments')
     def test_instrument_choices(self, mock_get_instruments):
         """Test LCOSpectroscopicSequenceForm._instrument_choices."""
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
 
         inst_choices = LCOSpectroscopicSequenceForm.instrument_choices()
         self.assertIn(('2M0-FLOYDS-SCICAM', '2.0 meter FLOYDS'), inst_choices)
@@ -513,7 +660,7 @@ class TestLCOSpectroscopicSequenceForm(TestCase):
     @patch('tom_observations.facilities.lco.LCOSpectroscopicSequenceForm._get_instruments')
     def test_filter_choices(self, mock_get_instruments):
         """Test LCOSpectroscopicSequenceForm._instrument_choices."""
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
 
         filter_choices = LCOSpectroscopicSequenceForm.filter_choices()
         for expected in [('slit_6.0as', '6.0 arcsec slit'), ('slit_1.6as', '1.6 arcsec slit'),
@@ -594,7 +741,7 @@ class TestLCOSpectroscopicSequenceForm(TestCase):
     @patch('tom_observations.facilities.lco.LCOSpectroscopicSequenceForm.validate_at_facility')
     @patch('tom_observations.facilities.lco.LCOSpectroscopicSequenceForm._get_instruments')
     def test_build_location(self, mock_get_instruments, mock_validate, mock_insts, mock_filters, mock_proposals):
-        mock_get_instruments.return_value = {k: v for k, v in instrument_response.items() if 'SOAR' not in k}
+        mock_get_instruments.return_value = generate_lco_instrument_choices()
         mock_validate.return_value = []
         mock_insts.return_value = self.instrument_choices
         mock_filters.return_value = self.filter_choices


### PR DESCRIPTION
Add support for observing on LCO's Muscat imaging instrument.

Muscat observation requests require a few different fields than normal imaging requests. There are separate fields for exposure times, one for each channel of the instrument instead of a single exposure time, and instead of a filter optical element, a diffuser optical element must be specified for each channel. In addition, an exposure mode and a guide mode are also selectable.

I hope I've added enough comments into the observing form itself, but let me know if anything does not make sense. I also tried to keep the style consistent with the rest of the page, but of course let me know if anything looks off.