### PR TITLE
update TNS URL

### DIFF
--- a/tom_alerts/brokers/tns.py
+++ b/tom_alerts/brokers/tns.py
@@ -7,8 +7,9 @@ from datetime import datetime, timedelta
 from crispy_forms.layout import Layout, Div, Fieldset
 
 
-tns_search_url = 'https://www.wis-tns.org/api/get/search'
-tns_object_url = 'https://www.wis-tns.org/api/get/object'
+TNS_BASE_URL = 'https://www.wis-tns.org/'
+TNS_OBJECT_URL = f'{TNS_BASE_URL}api/get/object'
+TNS_SEARCH_URL = f'{TNS_BASE_URL}api/get/search'
 
 
 class TNSForm(GenericQueryForm):
@@ -102,7 +103,7 @@ class TNSBroker(GenericBroker):
                 'public_timestamp': public_timestamp,
             })
          }
-        response = requests.post(tns_search_url, data)
+        response = requests.post(TNS_SEARCH_URL, data)
         response.raise_for_status()
         transients = response.json()
         alerts = []
@@ -115,7 +116,7 @@ class TNSBroker(GenericBroker):
                     'spectroscopy': 0,
                 })
             }
-            response = requests.post(tns_object_url, data)
+            response = requests.post(TNS_OBJECT_URL, data)
             response.raise_for_status()
             alert = response.json()['data']['reply']
 
@@ -138,7 +139,7 @@ class TNSBroker(GenericBroker):
     def to_generic_alert(cls, alert):
         return GenericAlert(
             timestamp=alert['discoverydate'],
-            url='https://www.wis-tns.org/object/' + alert['objname'],
+            url=f'{TNS_BASE_URL}object/' + alert['objname'],
             id=alert['objname'],
             name=alert['name_prefix'] + alert['objname'],
             ra=alert['radeg'],

--- a/tom_alerts/brokers/tns.py
+++ b/tom_alerts/brokers/tns.py
@@ -7,8 +7,8 @@ from datetime import datetime, timedelta
 from crispy_forms.layout import Layout, Div, Fieldset
 
 
-tns_search_url = 'https://wis-tns.weizmann.ac.il/api/get/search'
-tns_object_url = 'https://wis-tns.weizmann.ac.il/api/get/object'
+tns_search_url = 'https://www.wis-tns.org/api/get/search'
+tns_object_url = 'https://www.wis-tns.org/api/get/object'
 
 
 class TNSForm(GenericQueryForm):
@@ -75,7 +75,7 @@ class TNSForm(GenericQueryForm):
 class TNSBroker(GenericBroker):
     """
     The ``TNSBroker`` is the interface to the Transient Name Server. For information regarding the TNS, please see \
-    https://wis-tns.weizmann.ac.il/
+    https://www.wis-tns.org/
     """
 
     name = 'TNS'
@@ -138,7 +138,7 @@ class TNSBroker(GenericBroker):
     def to_generic_alert(cls, alert):
         return GenericAlert(
             timestamp=alert['discoverydate'],
-            url='https://wis-tns.weizmann.ac.il/object/' + alert['objname'],
+            url='https://www.wis-tns.org/object/' + alert['objname'],
             id=alert['objname'],
             name=alert['name_prefix'] + alert['objname'],
             ra=alert['radeg'],

--- a/tom_catalogs/harvesters/tns.py
+++ b/tom_catalogs/harvesters/tns.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from tom_catalogs.harvester import AbstractHarvester
 from tom_common.exceptions import ImproperCredentialsException
 
-TNS_URL = 'https://wis-tns.weizmann.ac.il'
+TNS_URL = 'https://www.wis-tns.org'
 
 try:
     TNS_CREDENTIALS = settings.HARVESTERS['TNS']
@@ -20,8 +20,6 @@ except (AttributeError, KeyError):
 
 
 def get(term):
-    # url = "https://wis-tns.weizmann.ac.il/api/get"
-
     get_url = TNS_URL + '/api/get/object'
 
     # change term to json format
@@ -44,7 +42,7 @@ def get(term):
 class TNSHarvester(AbstractHarvester):
     """
     The ``TNSBroker`` is the interface to the Transient Name Server. For information regarding the TNS, please see
-    https://wis-tns.weizmann.ac.il/.
+    https://www.wis-tns.org/.
     """
 
     name = 'TNS'


### PR DESCRIPTION
The Transient Name Server recently migrated their server to AWS, and now they have a new URL. See https://www.wis-tns.org/content/tns-newsfeed#comment-wrapper-20280 for more details.

I updated all instances of the wis-tns.weizmann.ac.il URL to www.wis-tns.org throughout the package.