### PR TITLE
Add default button for the Fink broker

### DIFF
--- a/tom_alerts/alerts.py
+++ b/tom_alerts/alerts.py
@@ -23,6 +23,7 @@ DEFAULT_ALERT_CLASSES = [
     'tom_alerts.brokers.antares.ANTARESBroker',
     'tom_alerts.brokers.gaia.GaiaBroker',
     'tom_alerts.brokers.scimma.SCIMMABroker',
+    'tom_alerts.brokers.fink.FinkBroker',
 ]
 
 

--- a/tom_alerts/brokers/fink.py
+++ b/tom_alerts/brokers/fink.py
@@ -1,0 +1,32 @@
+from crispy_forms.layout import Layout, HTML
+
+from tom_alerts.alerts import GenericBroker, GenericQueryForm, GenericAlert
+
+
+class FinkQueryForm(GenericQueryForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.inputs.pop()
+        self.helper.layout = Layout(
+            HTML('''
+                <p>
+                This plugin is a stub for the Fink plugin. In order to install the full plugin, please see the
+                instructions <a href="https://github.com/TOMToolkit/tom_fink">here</a>.
+                </p>
+            '''),
+            HTML('''<a class="btn btn-outline-primary" href={% url 'tom_alerts:list' %}>Back</a>''')
+        )
+
+
+class FinkBroker(GenericBroker):
+    name = 'Fink'
+    form = FinkQueryForm
+
+    def fetch_alerts(self, parameters):
+        return iter([])
+
+    def process_reduced_data(self, target, alert=None):
+        return
+
+    def to_generic_alert(self, alert):
+        return GenericAlert()

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -246,6 +246,7 @@ TOM_ALERT_CLASSES = [
     'tom_alerts.brokers.scimma.SCIMMABroker',
     'tom_alerts.brokers.scout.ScoutBroker',
     'tom_alerts.brokers.tns.TNSBroker',
+    'tom_alerts.brokers.fink.FinkBroker',
 ]
 
 BROKERS = {


### PR DESCRIPTION
This PR follows issue #440 by adding a default button for the Fink broker. After a fresh installation of `tom_base`, I have a new button `Fink` in the broker list, that shows:

<img width="1440" alt="Screenshot 2021-03-22 at 14 50 03" src="https://user-images.githubusercontent.com/20426972/112000123-f70bf300-8b1d-11eb-88ad-0f797ef5c514.png">
