### PR TITLE
Updated TNS URL

### DIFF
--- a/tom_alerts/brokers/tns.py
+++ b/tom_alerts/brokers/tns.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from crispy_forms.layout import Layout, Div, Fieldset
 
 
-TNS_BASE_URL = 'https://www.wis-tns.org/'
+TNS_BASE_URL = 'https://wis-tns.weizmann.ac.il'
 TNS_OBJECT_URL = f'{TNS_BASE_URL}api/get/object'
 TNS_SEARCH_URL = f'{TNS_BASE_URL}api/get/search'
 


### PR DESCRIPTION
Ofer Yaron, one of the TNS developers, reports by email that the old URL (www.wis-tns.org) is no longer being redirected, so I have updated the TNS_BASE_URL parameter. 