### PR TITLE
Make TOM name configurable

### DIFF
--- a/docs/common/customsettings.rst
+++ b/docs/common/customsettings.rst
@@ -294,3 +294,11 @@ Example:
       'REGISTRATION_REDIRECT_PATTERN': 'home',
       'SEND_APPROVAL_EMAILS': True
    }
+
+`TOM_NAME <#tom_name>`__
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: TOM Toolkit
+
+Set the name of the TOM, used for display purposes such as the navbar
+and page titles.

--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -32,6 +32,8 @@ ALLOWED_HOSTS = ['']
 
 # Application definition
 
+TOM_NAME = 'TOM Toolkit'
+
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',

--- a/tom_common/templates/tom_common/base.html
+++ b/tom_common/templates/tom_common/base.html
@@ -16,11 +16,11 @@
 
     {% bootstrap_javascript jquery='True' %}
 
-    <title>TOM Toolkit | {% block title %}{% endblock %}</title>
+    <title>{% tom_name %} | {% block title %}{% endblock %}</title>
   </head>
   <body>
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
-      <a class="navbar-brand" href="/"><img src="{% static 'tom_common/img/logo-color-cropped.png' %}" class="img-fluid"> TOM Toolkit</a>
+      <a class="navbar-brand" href="/"><img src="{% static 'tom_common/img/logo-color-cropped.png' %}" class="img-fluid"> {% tom_name %}</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/tom_common/templatetags/tom_common_extras.py
+++ b/tom_common/templatetags/tom_common_extras.py
@@ -71,3 +71,8 @@ def truncate_number(value):
         return '%.4f' % value
     except Exception:
         return value
+
+
+@register.simple_tag
+def tom_name():
+    return getattr(settings, 'TOM_NAME', 'TOM Toolkit')

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -33,6 +33,8 @@ ALLOWED_HOSTS = []
 
 # Application definition
 
+TOM_NAME = 'TOM Toolkit'
+
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',


### PR DESCRIPTION
It would be nice if users would not have to override
tom_common/base.html just to update the name of the TOM that is
displayed in the header and title of each page. I think those templates
are just fine.

This introduces a backwards compatible tag that pulls a TOM_NAME setting
from settings.py but defaults to "TOM Toolkit" in case that setting
doesn't exist. I added the setting to the setup template, but it might
be a good candidate to add to the setup script as an interactive
question as well.