### PR TITLE
Seperate Target list table into a partial

### DIFF
--- a/tom_targets/templates/tom_targets/partials/target_table.html
+++ b/tom_targets/templates/tom_targets/partials/target_table.html
@@ -1,0 +1,43 @@
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th><input type="checkbox" id="selectPage" onClick="select_page(this, {{ targets|length }})" /></th>
+      <th>Name</th>
+      <th>Type</th>
+      {% if request.GET.type == 'SIDEREAL' %}
+      <th>RA</th>
+      <th>Dec</th>
+      {% endif %}
+      <th>Observations</th>
+      <th>Saved Data</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for target in targets %}
+    <tr>
+      <td><input type="checkbox" name="selected-target" value="{{ target.id }}" onClick="single_select()"/></td>
+      <td>
+          <a href="{% url 'targets:detail' target.id %}" title="{{ target.name }}">{{ target.names|join:", " }}</a>
+      </td>
+      <td>{{ target.get_type_display }}</td>
+      {% if request.GET.type == 'SIDEREAL' %}
+      <td>{{ target.ra }}</td>
+      <td>{{ target.dec }}</td>
+      {% endif %}
+      <td>{{ target.observationrecord_set.count }}</td>
+      <td>{{ target.dataproduct_set.count }}</td>
+    </tr>
+    {% empty %}
+    <tr>
+      <td colspan="5">
+        {% if target_count == 0 and not query_string %}
+        No targets yet. You might want to <a href="{% url 'tom_targets:create' %}">create a target manually</a>
+        or <a href="{% url 'tom_alerts:list' %}">import one from an alert broker</a>.
+        {% else %}
+        No targets match those filters.
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/tom_targets/templates/tom_targets/target_list.html
+++ b/tom_targets/templates/tom_targets/target_list.html
@@ -41,49 +41,7 @@
         <button type="submit" class="btn btn-outline-primary ml-1" name="add">Add</button>
         <button type="submit" class="btn btn-outline-danger ml-1" name="remove">Remove</button>
       </div>
-      <table class="table table-hover">
-        <thead>
-          <tr>
-            <th><input type="checkbox" id="selectPage" onClick="select_page(this, {{ target_count }})" /></th>
-            <th>Name</th>
-            <th>Type</th>
-            {% if request.GET.type == 'SIDEREAL' %}
-            <th>RA</th>
-            <th>Dec</th>
-            {% endif %}
-            <th>Observations</th>
-            <th>Saved Data</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for target in object_list %}
-          <tr>
-            <td><input type="checkbox" name="selected-target" value="{{ target.id }}" onClick="single_select()"/></td>
-            <td>
-                <a href="{% url 'targets:detail' target.id %}" title="{{ target.name }}">{{ target.names|join:", " }}</a>
-            </td>
-            <td>{{ target.get_type_display }}</td>
-            {% if request.GET.type == 'SIDEREAL' %}
-            <td>{{ target.ra }}</td>
-            <td>{{ target.dec }}</td>
-            {% endif %}
-            <td>{{ target.observationrecord_set.count }}</td>
-            <td>{{ target.dataproduct_set.count }}</td>
-          </tr>
-          {% empty %}
-          <tr>
-            <td colspan="5">
-              {% if target_count == 0 and not query_string %}
-              No targets yet. You might want to <a href="{% url 'tom_targets:create' %}">create a target manually</a>
-              or <a href="{% url 'tom_alerts:list' %}">import one from an alert broker</a>.
-              {% else %}
-              No targets match those filters.
-              {% endif %}
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+      {% target_table object_list %}
     </form>
     {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
   </div>

--- a/tom_targets/templatetags/targets_extras.py
+++ b/tom_targets/templatetags/targets_extras.py
@@ -264,3 +264,12 @@ def aladin(target):
     and a scale bar. The resulting image is downloadable. This templatetag only works for sidereal targets.
     """
     return {'target': target}
+
+
+@register.inclusion_tag('tom_targets/partials/target_table.html')
+def target_table(targets):
+    """
+    Returns a partial for a table of targets, used in the target_list.html template
+    by default
+    """
+    return {'targets': targets}


### PR DESCRIPTION
It would be helpful to have the target list as it's own template so that
we can override it without overriding the entire page. A good example
would be adding columns to display in the table, while still being able
to get updates from upstream on the rest of the page.