### PR TITLE
Adds a move function for the target list

### DIFF
--- a/tom_targets/groups.py
+++ b/tom_targets/groups.py
@@ -28,7 +28,7 @@ def add_all_to_grouping(filter_data, grouping_object, request):
         return
     for target_object in target_queryset:
         try:
-            if not request.user.has_perm('tom_targets.view_target', target_object):
+            if not request.user.has_perm('tom_targets.change_target', target_object):
                 failure_targets.append((target_object.name, 'Permission denied.',))
             elif target_object in grouping_object.targets.all():
                 warning_targets.append(target_object.name)
@@ -67,7 +67,7 @@ def add_selected_to_grouping(targets_ids, grouping_object, request):
     for target_id in targets_ids:
         try:
             target_object = Target.objects.get(pk=target_id)
-            if not request.user.has_perm('tom_targets.view_target', target_object):
+            if not request.user.has_perm('tom_targets.change_target', target_object):
                 failure_targets.append((target_object.name, 'Permission denied.',))
             elif target_object in grouping_object.targets.all():
                 warning_targets.append(target_object.name)
@@ -111,7 +111,7 @@ def remove_all_from_grouping(filter_data, grouping_object, request):
         return
     for target_object in target_queryset:
         try:
-            if not request.user.has_perm('tom_targets.view_target', target_object):
+            if not request.user.has_perm('tom_targets.change_target', target_object):
                 failure_targets.append((target_object.name, 'Permission denied.',))
             elif target_object not in grouping_object.targets.all():
                 warning_targets.append(target_object.name)
@@ -150,7 +150,7 @@ def remove_selected_from_grouping(targets_ids, grouping_object, request):
     for target_id in targets_ids:
         try:
             target_object = Target.objects.get(pk=target_id)
-            if not request.user.has_perm('tom_targets.view_target', target_object):
+            if not request.user.has_perm('tom_targets.change_target', target_object):
                 failure_targets.append((target_object.name, 'Permission denied.',))
             elif target_object not in grouping_object.targets.all():
                 warning_targets.append(target_object.name)
@@ -196,7 +196,7 @@ def move_all_to_grouping(filter_data, grouping_object, request):
         return
     for target_object in target_queryset:
         try:
-            if not request.user.has_perm('tom_targets.view_target', target_object):
+            if not request.user.has_perm('tom_targets.change_target', target_object):
                 failure_targets.append((target_object.name, 'Permission denied.',))
             elif target_object in grouping_object.targets.all():
                 warning_targets.append(target_object.name)
@@ -238,7 +238,7 @@ def move_selected_to_grouping(targets_ids, grouping_object, request):
     for target_id in targets_ids:
         try:
             target_object = Target.objects.get(pk=target_id)
-            if not request.user.has_perm('tom_targets.view_target', target_object):
+            if not request.user.has_perm('tom_targets.change_target', target_object):
                 failure_targets.append((target_object.name, 'Permission denied.',))
             elif target_object in grouping_object.targets.all():
                 warning_targets.append(target_object.name)

--- a/tom_targets/groups.py
+++ b/tom_targets/groups.py
@@ -167,3 +167,92 @@ def remove_selected_from_grouping(targets_ids, grouping_object, request):
     for failure_target in failure_targets:
         messages.error(request, "Failed to remove target with id={} from group '{}'; {}"
                                 .format(failure_target['id'], grouping_object.name, failure_target['error']))
+
+
+def move_all_to_grouping(filter_data, grouping_object, request):
+    """
+    Moves all targets displayed by a particular filter to a ``TargetList`` by removing all previous gropupings
+    and then adding them to the supplied grouping_object.
+    Successes, warnings, and errors result
+    in messages being added to the request with the appropriate message level.
+
+    :param filter_data: target filter data passed to the calling view
+    :type filter_data: django.http.QueryDict
+
+    :param grouping_object: ``TargetList`` to add targets to
+    :type grouping_object: TargetList
+
+    :param request: request object passed to the calling view
+    :type request: HTTPRequest
+    """
+    success_targets = []
+    warning_targets = []
+    failure_targets = []
+    try:
+        target_queryset = TargetFilter(request=request, data=filter_data, queryset=Target.objects.all()).qs
+    except Exception:
+        messages.error(request, "Error with filter parameters. No target(s) were moved to group '{}'."
+                                .format(grouping_object.name))
+        return
+    for target_object in target_queryset:
+        try:
+            if not request.user.has_perm('tom_targets.view_target', target_object):
+                failure_targets.append((target_object.name, 'Permission denied.',))
+            elif target_object in grouping_object.targets.all():
+                warning_targets.append(target_object.name)
+            else:
+                target_object.targetlist_set.clear()
+                grouping_object.targets.add(target_object)
+                success_targets.append(target_object.name)
+        except Exception as e:
+            failure_targets.append({'name': target_object.name, 'error': e})
+    messages.success(request, "{} target(s) successfully moved to group '{}'."
+                              .format(len(success_targets), grouping_object.name))
+    if warning_targets:
+        messages.warning(request, "{} target(s) already in group '{}': {}"
+                                  .format(len(warning_targets), grouping_object.name, ', '.join(warning_targets)))
+    for failure_target in failure_targets:
+        messages.error(request, "Failed to move target with id={} to group '{}'; {}"
+                                .format(failure_target['id'], grouping_object.name, failure_target['error']))
+
+
+def move_selected_to_grouping(targets_ids, grouping_object, request):
+    """
+    Moves all selected targets to a ``TargetList`` by removing them from their previous groupings
+    and then adding them to the supplied grouping_object.
+    Successes, warnings, and errors result in messages being added to the
+    request with the appropriate message level.
+
+    :param targets_ids: list of selected targets
+    :type targets_ids: list
+
+    :param grouping_object: ``TargetList`` to add targets to
+    :type grouping_object: TargetList
+
+    :param request: request object passed to the calling view
+    :type request: HTTPRequest
+    """
+    success_targets = []
+    warning_targets = []
+    failure_targets = []
+    for target_id in targets_ids:
+        try:
+            target_object = Target.objects.get(pk=target_id)
+            if not request.user.has_perm('tom_targets.view_target', target_object):
+                failure_targets.append((target_object.name, 'Permission denied.',))
+            elif target_object in grouping_object.targets.all():
+                warning_targets.append(target_object.name)
+            else:
+                target_object.targetlist_set.clear()
+                grouping_object.targets.add(target_object)
+                success_targets.append(target_object.name)
+        except Exception as e:
+            failure_targets.append((target_id, e,))
+    messages.success(request, "{} target(s) successfully moved to group '{}'."
+                              .format(len(success_targets), grouping_object.name))
+    if warning_targets:
+        messages.warning(request, "{} target(s) already in group '{}': {}"
+                                  .format(len(warning_targets), grouping_object.name, ', '.join(warning_targets)))
+    for failure_target in failure_targets:
+        messages.error(request, "Failed to move target with id={} to group '{}'; {}"
+                                .format(failure_target[0], grouping_object.name, failure_target[1]))

--- a/tom_targets/templates/tom_targets/target_list.html
+++ b/tom_targets/templates/tom_targets/target_list.html
@@ -39,6 +39,7 @@
         <input type="hidden" value="{{ query_string }}" name="query_string">
         <input type="hidden" value="False" id="isSelectAll" name="isSelectAll">
         <button type="submit" class="btn btn-outline-primary ml-1" name="add">Add</button>
+        <button type="submit" class="btn btn-outline-primary ml-1" name="move">Move</button>
         <button type="submit" class="btn btn-outline-danger ml-1" name="remove">Remove</button>
       </div>
       {% target_table object_list %}

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -696,6 +696,7 @@ class TestTargetAddRemoveGrouping(TestCase):
             ft = SiderealTargetFactory.create()
             self.fake_targets.append(ft)
             assign_perm('tom_targets.view_target', user, ft)
+            assign_perm('tom_targets.change_target', user, ft)
         # create grouping
         self.fake_grouping = TargetGroupingFactory.create()
         assign_perm('tom_targets.view_targetlist', user, self.fake_grouping)

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -754,6 +754,53 @@ class TestTargetAddRemoveGrouping(TestCase):
         self.assertIn(('1 target(s) not in group \'{}\': {}'.format(self.fake_grouping.name, self.fake_targets[1].name),
                        WARNING), messages)
 
+    # Add target[0] and [1] to grouping; [0] already exists and [1] new
+    def test_move_selected_to_grouping(self):
+        data = {
+            'grouping': self.fake_grouping.id,
+            'move': True,
+            'isSelectAll': 'False',
+            'selected-target': [self.fake_targets[0].id, self.fake_targets[1].id],
+            'query_string': '',
+        }
+        first_grouping = TargetGroupingFactory.create()
+        self.fake_targets[0].targetlist_set.add(first_grouping)
+        self.fake_targets[1].targetlist_set.add(first_grouping)
+        response = self.client.post(reverse('targets:add-remove-grouping'), data=data)
+
+        self.assertEqual(self.fake_grouping.targets.count(), 2)
+        self.assertTrue(self.fake_targets[0] in self.fake_grouping.targets.all())
+        self.assertTrue(self.fake_targets[1] in self.fake_grouping.targets.all())
+        self.assertTrue(self.fake_targets[0] in first_grouping.targets.all())
+        self.assertFalse(self.fake_targets[1] in first_grouping.targets.all())
+
+        messages = [(m.message, m.level) for m in get_messages(response.wsgi_request)]
+        self.assertIn(('1 target(s) successfully moved to group \'{}\'.'.format(self.fake_grouping.name),
+                       SUCCESS), messages)
+        self.assertIn(('1 target(s) already in group \'{}\': {}'.format(
+            self.fake_grouping.name, self.fake_targets[0].name), WARNING), messages)
+
+    def test_move_all_to_grouping_filtered_by_sidereal(self):
+        data = {
+            'grouping': self.fake_grouping.id,
+            'move': True,
+            'isSelectAll': 'True',
+            'selected-target': [],
+            'query_string': 'type=SIDEREAL&name=&key=&value=&targetlist__name=',
+        }
+        first_grouping = TargetGroupingFactory.create()
+        first_grouping.targets.add(*self.fake_targets)
+        response = self.client.post(reverse('targets:add-remove-grouping'), data=data)
+        self.assertEqual(self.fake_grouping.targets.count(), 3)
+        self.assertEqual(first_grouping.targets.count(), 1)
+        messages = [(m.message, m.level) for m in get_messages(response.wsgi_request)]
+        self.assertIn(('2 target(s) successfully moved to group \'{}\'.'.format(self.fake_grouping.name),
+                       SUCCESS), messages)
+        self.assertIn((
+            '1 target(s) already in group \'{}\': {}'.format(self.fake_grouping.name, self.fake_targets[0].name),
+            WARNING), messages
+        )
+
     def test_empty_data(self):
         self.client.post(reverse('targets:add-remove-grouping'), data={'query_string': ''})
         self.assertEqual(self.fake_grouping.targets.count(), 1)

--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -36,7 +36,8 @@ from tom_targets.forms import (
     SiderealTargetCreateForm, NonSiderealTargetCreateForm, TargetExtraFormset, TargetNamesFormset
 )
 from tom_targets.groups import (
-    add_all_to_grouping, add_selected_to_grouping, remove_all_from_grouping, remove_selected_from_grouping
+    add_all_to_grouping, add_selected_to_grouping, remove_all_from_grouping, remove_selected_from_grouping,
+    move_all_to_grouping, move_selected_to_grouping
 )
 from tom_targets.models import Target, TargetList
 from tom_targets.utils import import_targets, export_targets
@@ -476,6 +477,13 @@ class TargetAddRemoveGroupingView(LoginRequiredMixin, View):
             else:
                 targets_ids = request.POST.getlist('selected-target')
                 remove_selected_from_grouping(targets_ids, grouping_object, request)
+        if 'move' in request.POST:
+            if request.POST.get('isSelectAll') == 'True':
+                move_all_to_grouping(filter_data, grouping_object, request)
+            else:
+                target_ids = request.POST.getlist('selected-target')
+                move_selected_to_grouping(target_ids, grouping_object, request)
+
         return redirect(reverse('tom_targets:list') + '?' + query_string)
 
 


### PR DESCRIPTION
This PR adds functions for moving targets between TargetLists. If a
target is moved to a TargetList, it's previous lists are cleared and
the target is added to the specified TargetList. If the target already
exists in the specified TargetList a warning is displayed but the
target's previous associations are not changed.

In addition a button is added to the top of the target table alongside
the add/remove buttons.

This is a faster way of doing remove/add for a large quantity of
targets.