### PR TITLE
Fix query for the "Recent Photometry" table

### DIFF
--- a/tom_dataproducts/templatetags/dataproduct_extras.py
+++ b/tom_dataproducts/templatetags/dataproduct_extras.py
@@ -98,7 +98,7 @@ def recent_photometry(target, limit=1):
     """
     Displays a table of the most recent photometric points for a target.
     """
-    photometry = ReducedDatum.objects.filter(data_type='photometry').order_by('-timestamp')[:limit]
+    photometry = ReducedDatum.objects.filter(data_type='photometry', target=target).order_by('-timestamp')[:limit]
     return {'data': [{'timestamp': rd.timestamp, 'magnitude': rd.value['magnitude']} for rd in photometry]}
 
 


### PR DESCRIPTION
The query doesn't actually filter by target, so it does not reflect
recent photometry for the target displayed on the Target Detail page.