### PR TITLE
Add mag error and nondetections to mars and plot

### DIFF
--- a/tom_alerts/brokers/mars.py
+++ b/tom_alerts/brokers/mars.py
@@ -11,7 +11,7 @@ from tom_targets.models import Target
 from tom_dataproducts.models import ReducedDatum
 
 MARS_URL = 'https://mars.lco.global'
-filters = {0: 'g', 1: 'r', 2: 'i'}
+filters = {1: 'g', 2: 'r', 3: 'i'}
 
 
 class MARSQueryForm(GenericQueryForm):
@@ -226,21 +226,29 @@ class MARSBroker(GenericBroker):
 
         candidates = [{'candidate': alert.get('candidate')}] + alert.get('prv_candidate')
         for candidate in candidates:
-            if all([key in candidate['candidate'] for key in ['jd', 'magpsf', 'fid']]):
-                jd = Time(candidate['candidate']['jd'], format='jd', scale='utc')
-                jd.to_datetime(timezone=TimezoneInfo())
-                value = {
-                    'magnitude': candidate['candidate']['magpsf'],
-                    'filter': filters[candidate['candidate']['fid']]
-                }
-                rd, _ = ReducedDatum.objects.get_or_create(
-                    timestamp=jd.to_datetime(timezone=TimezoneInfo()),
-                    value=value,
-                    source_name=self.name,
-                    source_location=alert['lco_id'],
-                    data_type='photometry',
-                    target=target)
-                rd.save()
+            if all([key in candidate['candidate'] for key in ['jd', 'magpsf', 'fid', 'sigmapsf']]):
+                nondetection = False
+            elif all(key in candidate['candidate'] for key in ['jd', 'diffmaglim', 'fid']):
+                nondetection = True
+            else:
+                continue
+            jd = Time(candidate['candidate']['jd'], format='jd', scale='utc')
+            jd.to_datetime(timezone=TimezoneInfo())
+            value = {
+                'filter': filters[candidate['candidate']['fid']]
+            }
+            if nondetection:
+                value['limit'] = candidate['candidate']['diffmaglim']
+            else:
+                value['magnitude'] = candidate['candidate']['magpsf']
+                value['error'] = candidate['candidate']['sigmapsf']
+            rd, _ = ReducedDatum.objects.get_or_create(
+                timestamp=jd.to_datetime(timezone=TimezoneInfo()),
+                value=value,
+                source_name=self.name,
+                source_location=alert['lco_id'],
+                data_type='photometry',
+                target=target)
 
     def to_target(self, alert):
         alert_copy = alert.copy()

--- a/tom_alerts/tests/brokers/test_mars.py
+++ b/tom_alerts/tests/brokers/test_mars.py
@@ -79,7 +79,8 @@ class TestMARSBrokerClass(TestCase):
                 'candidate': {
                     'jd': 2458372.6225231,
                     'magpsf': 13,
-                    'fid': 0
+                    'sigmapsf': 0.5,
+                    'fid': 1
                 }
             }
         ]
@@ -96,7 +97,8 @@ class TestMARSBrokerClass(TestCase):
                 'candidate': {
                     'jd': 2458372.6225231,
                     'magpsf': 13,
-                    'fid': 0
+                    'sigmapsf': 0.5,
+                    'fid': 1
                 }
             }
         ]

--- a/tom_dataproducts/templatetags/dataproduct_extras.py
+++ b/tom_dataproducts/templatetags/dataproduct_extras.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 from django import template
 from django.conf import settings
 from django.contrib.auth.models import Group
+from django.core.management import color
 from django.core.paginator import Paginator
 from django.shortcuts import reverse
 from datetime import datetime
@@ -110,6 +111,12 @@ def photometry_for_target(context, target):
     This templatetag requires all ``ReducedDatum`` objects with a data_type of ``photometry`` to be structured with the
     following keys in the JSON representation: magnitude, error, filter
     """
+
+    color_map = {
+        'r': 'red',
+        'g': 'green',
+        'i': 'black'
+    }
     photometry_data = {}
     if settings.TARGET_PERMISSIONS_ONLY:
         datums = ReducedDatum.objects.filter(target=target, data_type=settings.DATA_PRODUCT_TYPES['photometry'][0])
@@ -125,17 +132,36 @@ def photometry_for_target(context, target):
         photometry_data[datum.value['filter']].setdefault('time', []).append(datum.timestamp)
         photometry_data[datum.value['filter']].setdefault('magnitude', []).append(datum.value.get('magnitude'))
         photometry_data[datum.value['filter']].setdefault('error', []).append(datum.value.get('error'))
-    plot_data = [
-        go.Scatter(
-            x=filter_values['time'],
-            y=filter_values['magnitude'], mode='markers',
-            name=filter_name,
-            error_y=dict(
-                type='data',
-                array=filter_values['error'],
-                visible=True
+        photometry_data[datum.value['filter']].setdefault('limit', []).append(datum.value.get('limit'))
+
+    plot_data = []
+    for filter_name, filter_values in photometry_data.items():
+        if filter_values['magnitude']:
+            series = go.Scatter(
+                x=filter_values['time'],
+                y=filter_values['magnitude'],
+                mode='markers',
+                marker=dict(color=color_map[filter_name]),
+                name=filter_name,
+                error_y=dict(
+                    type='data',
+                    array=filter_values['error'],
+                    visible=True
+                )
             )
-        ) for filter_name, filter_values in photometry_data.items()]
+            plot_data.append(series)
+        if filter_values['limit']:
+            series = go.Scatter(
+                x=filter_values['time'],
+                y=filter_values['limit'],
+                mode='markers',
+                opacity=0.5,
+                marker=dict(color=color_map[filter_name]),
+                marker_symbol=6,  # upside down triangle
+                name=filter_name + ' non-detection',
+            )
+            plot_data.append(series)
+
     layout = go.Layout(
         yaxis=dict(autorange='reversed'),
         height=600,

--- a/tom_dataproducts/templatetags/dataproduct_extras.py
+++ b/tom_dataproducts/templatetags/dataproduct_extras.py
@@ -3,7 +3,6 @@ from urllib.parse import urlencode
 from django import template
 from django.conf import settings
 from django.contrib.auth.models import Group
-from django.core.management import color
 from django.core.paginator import Paginator
 from django.shortcuts import reverse
 from datetime import datetime


### PR DESCRIPTION
This PR implements a few things:

1. Adds support for importing magnitude error from MARS lightcurves.
2. Adds support for importing non detections from MARS lightcurves.
3. Implements plotting both of the above on the photometry for target
   plot.
4. Fixes photometry being saved under the wrong filter.

I hope you will consider mergint this, as by default the photometry plot
is missing quite a bit of useful data.

![image](https://user-images.githubusercontent.com/3046397/129286914-2b1a9281-796e-440d-8567-6e39c5a0f162.png)
