### PR TITLE
Do not artificially limit alert results

### DIFF
--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -204,7 +204,7 @@ class RunQueryView(TemplateView):
         query.save()
         context['query'] = query
         try:
-            while len(context['alerts']) < 20:
+            while True:
                 alert = next(alerts)
                 generic_alert = broker_class.to_generic_alert(alert)
                 cache.set('alert_{}'.format(generic_alert.id), json.dumps(alert), 3600)


### PR DESCRIPTION
This was probably put in here for testing and not removed, but the
results from alert brokers should not be limited, but if they must be
limited, it should be documented somewhere on the template. I think it
should be fine to just return them all since the TOM has already
downloaded them all at this point.