### PR TITLE
Fixes the CSS/HTML so navbar displays properly

### DIFF
--- a/tom_common/templates/tom_common/navbar_content.html
+++ b/tom_common/templates/tom_common/navbar_content.html
@@ -8,15 +8,11 @@ For customization instructions, see tom_common/base.html
     <a class="nav-link" href="/">Home <span class="sr-only">(current)</span></a>
 </li>
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" data-toggle="dropdown">Targets</a>
-    <ul class="dropdown-menu">
-        <li class="nav-item {% if request.resolver_match.namespace == 'targets' %}active{% endif %}">
-            <a class="nav-link" href="{% url 'targets:list' %}"><font color="black">Targets</font></a>
-        </li>
-        <li class="nav-item {% if request.resolver_match.namespace == 'targets' %}active{% endif %}">
-            <a class="nav-link" href="{% url 'targets:targetgrouping' %}"><font color="black">Target Grouping</font></a>
-        </li>
-    </ul>
+    <a class="nav-link dropdown-toggle {% if request.resolver_match.namespace == 'targets' %}active{% endif %}" data-toggle="dropdown">Targets</a>
+    <div class="dropdown-menu">
+        <a class="dropdown-item" href="{% url 'targets:list' %}">Targets</a>
+        <a class="dropdown-item" href="{% url 'targets:targetgrouping' %}">Target Grouping</a>
+    </div>
 </li>
 <li class="nav-item {% if request.resolver_match.namespace == 'alerts' %}active{% endif %}">
     <a class="nav-link" href="{% url 'alerts:list' %}">Alerts</a>


### PR DESCRIPTION
The text for dropdowns was hardcoded to black, which is not good if you
want to use an astronomer approved all dark mode theme.

Applying the correct classes and html removes the need for hardcoding
black, and I think I also fixed the intended behavior of the"acive"
class, which looks a lot better now.