### PR TITLE
Adds an ordering option to the target list page

### DIFF
--- a/tom_targets/filters.py
+++ b/tom_targets/filters.py
@@ -112,6 +112,15 @@ class TargetFilter(django_filters.FilterSet):
 
     targetlist__name = django_filters.ModelChoiceFilter(queryset=get_target_list_queryset, label="Target Grouping")
 
+    order = django_filters.OrderingFilter(
+        fields=['name', 'created', 'modified'],
+        field_labels={
+            'name': 'Name',
+            'created': 'Creation Date',
+            'modified': 'Last Update'
+        }
+    )
+
     class Meta:
         model = Target
         fields = ['type', 'name', 'key', 'value', 'cone_search', 'targetlist__name']


### PR DESCRIPTION
This PR adds a django_fitlers.OrderingFilter to the filter form on the
target list page, allowing users to choose the order in which to display
targets in the table.

The SD Tom requires this because we frequently update our targets and
would like targets with recent updates to appear higher in the list.