### PR TITLE
Hides large TAGS header on target detail

### DIFF
--- a/tom_targets/templates/tom_targets/partials/target_data.html
+++ b/tom_targets/templates/tom_targets/partials/target_data.html
@@ -29,10 +29,12 @@
   <dd class="col-sm-6">{{ value }}</dd>
 {% endfor %}
 </dl>
-<h4>Tags</h4>
+{% if target.tags %}
+<p>Tags</p>
 <dl class="row">
 {% for key, value in target.tags.items %}
   <dt class="col-sm-6">{{ key }}</dt>
   <dd class="col-sm-6">{{ value }}</dd>
 {% endfor %}
 </dl>
+{% endif %}


### PR DESCRIPTION
On the target detail, there is a large, unsightly TAGS header item in
the left column, which appears whether or not the target has any tags
defined. This change hides the section unless the target has any tags,
as well as tones down the font size a bit even when it does.