### PR TITLE
Updated django-filter version for new CalVer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'django-contrib-comments~=2.0',  # Earlier version are incompatible with Django >= 3.0
         'django-crispy-forms~=1.11',
         'django-extensions~=3.1',
-        'django-filter~=2.4',
+        'django-filter~=21.0.0',
         'django-gravatar2~=1.4',
         'django-guardian~=2.3',
         'fits2image==0.4.4',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'django-contrib-comments~=2.0',  # Earlier version are incompatible with Django >= 3.0
         'django-crispy-forms~=1.11',
         'django-extensions~=3.1',
-        'django-filter~=21.0.0',
+        'django-filter~=21.0',
         'django-gravatar2~=1.4',
         'django-guardian~=2.3',
         'fits2image==0.4.4',


### PR DESCRIPTION
`django-filter` has switched from semantic versioning to calendar versioning. While there's a Dependabot PR, it includes a version band of 2.4 < version < 22, which could cause issues if for some reason a version is mistakenly released in that wide band.

This PR should supercede #504 and #504 should be closed.