### PR TITLE
Fixed simbad canary test, added exception handling to catalog search

### DIFF
--- a/tom_catalogs/harvesters/simbad.py
+++ b/tom_catalogs/harvesters/simbad.py
@@ -19,8 +19,8 @@ class SimbadHarvester(AbstractHarvester):
     def query(self, term):
         try:
             self.catalog_data = self.simbad.query_object(term)
-        except TableParseError:
-            self.catalog_data = None
+        except TableParseError:  # SIMBAD will raise a TableParseError if a result is not found
+            self.catalog_data = None  # The CatalogQueryView will display a proper error if catalog_data is None
 
     def to_target(self):
         target = super().to_target()

--- a/tom_catalogs/harvesters/simbad.py
+++ b/tom_catalogs/harvesters/simbad.py
@@ -1,6 +1,7 @@
 from tom_catalogs.harvester import AbstractHarvester
 
 from astroquery.simbad import Simbad
+from astroquery.exceptions import TableParseError
 
 
 class SimbadHarvester(AbstractHarvester):
@@ -16,7 +17,10 @@ class SimbadHarvester(AbstractHarvester):
         self.simbad.add_votable_fields('pmra', 'pmdec', 'ra(d)', 'dec(d)', 'id', 'parallax', 'distance')
 
     def query(self, term):
-        self.catalog_data = self.simbad.query_object(term)
+        try:
+            self.catalog_data = self.simbad.query_object(term)
+        except TableParseError:
+            self.catalog_data = None
 
     def to_target(self):
         target = super().to_target()

--- a/tom_catalogs/tests/harvesters/test_simbad.py
+++ b/tom_catalogs/tests/harvesters/test_simbad.py
@@ -15,7 +15,7 @@ class TestSimbadHarvester(TestCase):
                       'Distance_distance': [0.8200]}
         self.broker.catalog_data = Table(table_data)
 
-    def test_query_failure(self, mock_simbad):
+    def test_query_failure(self):
         self.broker.simbad = MagicMock()
         self.broker.simbad.query_object.side_effect = TableParseError()
         self.broker.query('M31')

--- a/tom_catalogs/tests/harvesters/test_simbad.py
+++ b/tom_catalogs/tests/harvesters/test_simbad.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+from astroquery.exceptions import TableParseError
 from astropy.table import Table
 from django.test import tag, TestCase
 
@@ -11,6 +14,12 @@ class TestSimbadHarvester(TestCase):
                       'PMRA': ['--'], 'PMDEC': ['--'], 'ID': ['M 31, 2C 56, DA 21'],
                       'Distance_distance': [0.8200]}
         self.broker.catalog_data = Table(table_data)
+
+    @patch('tom_catalogs.harvesters.simbad.Simbad.query_object')
+    def test_query_failure(self, mock_query_object):
+        mock_query_object.side_effect = TableParseError()
+        self.broker.query('M31')
+        self.assertIsNone(self.broker.catalog_data)
 
     def test_to_target(self):
         target = self.broker.to_target()

--- a/tom_catalogs/tests/harvesters/test_simbad.py
+++ b/tom_catalogs/tests/harvesters/test_simbad.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 from astroquery.exceptions import TableParseError
 from astropy.table import Table
@@ -15,9 +15,9 @@ class TestSimbadHarvester(TestCase):
                       'Distance_distance': [0.8200]}
         self.broker.catalog_data = Table(table_data)
 
-    @patch('tom_catalogs.harvesters.simbad.Simbad.query_object')
-    def test_query_failure(self, mock_query_object):
-        mock_query_object.side_effect = TableParseError()
+    def test_query_failure(self, mock_simbad):
+        self.broker.simbad = MagicMock()
+        self.broker.simbad.query_object.side_effect = TableParseError()
         self.broker.query('M31')
         self.assertIsNone(self.broker.catalog_data)
 

--- a/tom_catalogs/tests/harvesters/test_simbad.py
+++ b/tom_catalogs/tests/harvesters/test_simbad.py
@@ -28,8 +28,8 @@ class TestSimbadHarvesterCanary(TestCase):
         self.broker = SimbadHarvester()
 
     def test_query(self):
-        self.broker.query('M31')
+        self.broker.query('HD 289002')
         target = self.broker.to_target()
-        self.assertEqual(target.name, 'M31')
-        self.assertAlmostEqual(target.ra, 10.684708, places=3)
-        self.assertAlmostEqual(target.dec, 41.26875, places=3)
+        self.assertEqual(target.name, 'HD289002')
+        self.assertAlmostEqual(target.ra, 101.306, places=3)
+        self.assertAlmostEqual(target.dec, 2.137, places=3)


### PR DESCRIPTION
Canary tests have been failing for 16 nights. While almost all of them are due to a bizarre unreproducible specutils error, the very first one was a SIMBAD query failure. The SIMBAD script service no longer returns data for Messier objects, so the change to HD289002 should resolve the issue.

The fact that the SIMBAD harvester module will no longer return Messier objects should be noted, but the new exception handling probably means that it's not a bug.