### PR TITLE
Allow Brokers to Describe Use of `GenericAlert.score`

### DIFF
--- a/tom_alerts/alerts.py
+++ b/tom_alerts/alerts.py
@@ -179,6 +179,7 @@ class GenericBroker(ABC):
     https://github.com/TOMToolkit/tom_base/blob/main/tom_alerts/brokers/mars.py
     """
     alert_submission_form = GenericUpstreamSubmissionForm
+    score_description = "The meaning of this field changes between brokers, please consult this broker's documentation."
 
     @abstractmethod
     def fetch_alerts(self, parameters: dict):

--- a/tom_alerts/templates/tom_alerts/query_result.html
+++ b/tom_alerts/templates/tom_alerts/query_result.html
@@ -11,7 +11,16 @@
   </div>
   <table class="table table-striped">
     <thead>
-      <tr><th></th><th>Time</th><th>Name</th><th>RA</th><th>Dec</th><th>Mag</th><th>Score</th><th>View</th></tr>
+      <tr>
+        <th></th>
+        <th>Time</th>
+        <th>Name</th>
+        <th>RA</th>
+        <th>Dec</th>
+        <th>Mag</th>
+        <th><span title="{{ score_description }}">Score</span></th>
+        <th>View</th>
+      </tr>
     </thead>
     <tbody>
       {% for alert in alerts %}

--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -199,6 +199,7 @@ class RunQueryView(TemplateView):
         query = get_object_or_404(BrokerQuery, pk=self.kwargs['pk'])
         broker_class = get_service_class(query.broker)()
         alerts = broker_class.fetch_alerts(deepcopy(query.parameters))  # TODO: Should the deepcopy be in the brokers?
+        context['score_description'] = broker_class.score_description
         context['alerts'] = []
         query.last_run = timezone.now()
         query.save()


### PR DESCRIPTION
This change would allow brokers to describe their use of `GenericAlert.score` in a way that makes it into the UI.