### PR TITLE
protect against none extra

### DIFF
--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -428,7 +428,7 @@ class TargetExtra(models.Model):
         Saves TargetExtra model data to the database. In the process, converts the string value of the ``TargetExtra``
         to the appropriate type, and stores it in the corresponding field as well.
         """
-        if self.value == None:
+        if self.value is None:
             self.value = 'None'
         try:
             self.float_value = float(self.value)

--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -448,7 +448,6 @@ class TargetExtra(models.Model):
                 self.time_value = None
         else:
             self.time_value = None
-            
         super().save(*args, **kwargs)
 
     def typed_value(self, type_val):

--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -428,6 +428,8 @@ class TargetExtra(models.Model):
         Saves TargetExtra model data to the database. In the process, converts the string value of the ``TargetExtra``
         to the appropriate type, and stores it in the corresponding field as well.
         """
+        if self.value == None:
+            self.value = 'None'
         try:
             self.float_value = float(self.value)
         except (TypeError, ValueError, OverflowError):

--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -438,14 +438,17 @@ class TargetExtra(models.Model):
             self.bool_value = bool(self.value)
         except (TypeError, ValueError, OverflowError):
             self.bool_value = None
-        try:
-            if isinstance(self.value, datetime):
-                self.time_value = self.value
-            else:
-                self.time_value = parse(self.value)
-        except (TypeError, ValueError, OverflowError):
+        if not self.float_value:
+            try:
+                if isinstance(self.value, datetime):
+                    self.time_value = self.value
+                else:
+                    self.time_value = parse(self.value)
+            except (TypeError, ValueError, OverflowError):
+                self.time_value = None
+        else:
             self.time_value = None
-
+            
         super().save(*args, **kwargs)
 
     def typed_value(self, type_val):

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -318,6 +318,11 @@ class TestTargetCreate(TestCase):
         target.save(extras={'foo': 5})
         self.assertTrue(TargetExtra.objects.filter(target=target, key='foo', value='5').exists())
 
+    def test_none_extra(self):
+        target = SiderealTargetFactory.create()
+        target.save(extras={'foo': None})
+        self.assertTrue(TargetExtra.objects.filter(target=target, key='foo').exists())
+
     def test_non_sidereal_required_fields(self):
         base_data = {
             'name': 'nonsidereal_target',

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -329,7 +329,7 @@ class TestTargetCreate(TestCase):
         Casting a datetime from an int will indicate that year on an arbitrary day. '''
         target = SiderealTargetFactory.create()
         target.save(extras={'foo': '1984'})
-        te = target.targetextra_set.get(key = 'foo')
+        te = target.targetextra_set.get(key='foo')
         self.assertEquals(te.typed_value('number'), 1984.0)
         self.assertIsNone(te.typed_value('datetime'))
 

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -323,6 +323,17 @@ class TestTargetCreate(TestCase):
         target.save(extras={'foo': None})
         self.assertTrue(TargetExtra.objects.filter(target=target, key='foo').exists())
 
+    def test_datetime_warning(self):
+        '''Tests for an int that might come in and get mistakenly parsed for a datetime
+        If the value can be successfully cast as a float it it not useful to us as a datetime
+        Casting a datetime from an int will indicate that year on an arbitrary day. '''
+        target = SiderealTargetFactory.create()
+        target.save(extras={'foo': '1984'})
+        te = target.targetextra_set.get(key = 'foo')
+        self.assertEquals(te.typed_value('number'), 1984.0)
+        self.assertIsNone(te.typed_value('datetime'))
+
+
     def test_non_sidereal_required_fields(self):
         base_data = {
             'name': 'nonsidereal_target',

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -325,14 +325,13 @@ class TestTargetCreate(TestCase):
 
     def test_datetime_warning(self):
         '''Tests for an int that might come in and get mistakenly parsed for a datetime
-        If the value can be successfully cast as a float it it not useful to us as a datetime
+        If the value can be successfully cast as a float it is not useful to us as a datetime
         Casting a datetime from an int will indicate that year on an arbitrary day. '''
         target = SiderealTargetFactory.create()
         target.save(extras={'foo': '1984'})
         te = target.targetextra_set.get(key = 'foo')
         self.assertEquals(te.typed_value('number'), 1984.0)
         self.assertIsNone(te.typed_value('datetime'))
-
 
     def test_non_sidereal_required_fields(self):
         base_data = {


### PR DESCRIPTION
If a user attempts to save a None type as an extra django will throw a database error
.`django.db.utils.IntegrityError: NOT NULL constraint failed: tom_targets_targetextra.value`
As brokers provide data on targets sometimes an element of the alert is a None that has not been cast to a string or otherwise process. If a user were to try to save the alert as a bunch of TargetExtras django would not allow the None to be put into the database. This fix checks the parameter to be saved in TargetExtra, if it is `None` type then it rewrites the value as the string `'None'` 