### PR TITLE
remove SOARFacility.get_facility_status inheritance

### DIFF
--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -1245,34 +1245,38 @@ class LCOFacility(BaseRoboticObservationFacility):
 
         # set up the return value to be populated by the for loop below
         facility_status = {
-            'code': 'LCO',
+            'code': self.name,
             'sites': []
         }
+        site_list = [site["sitecode"] for site in self.SITES.values()]
 
         for telescope_key, telescope_value in telescope_states.items():
             [site_code, _, _] = telescope_key.split('.')
+            
+            # limit returned sites to those provided by the facility
+            if site_code in site_list:
 
-            # extract this telescope and it's status from the response
-            telescope = {
-                'code': telescope_key,
-                'status': telescope_value[0]['event_type']
-            }
-
-            # get the site dictionary from the facilities list of sites
-            # filter by site_code and provide a default (None) for new sites
-            site = next((site_ix for site_ix in facility_status['sites']
-                         if site_ix['code'] == site_code), None)
-            # create the site if it's new and not yet in the facility_status['sites] list
-            if site is None:
-                new_site = {
-                    'code': site_code,
-                    'telescopes': []
+                # extract this telescope and it's status from the response
+                telescope = {
+                    'code': telescope_key,
+                    'status': telescope_value[0]['event_type']
                 }
-                facility_status['sites'].append(new_site)
-                site = new_site
 
-            # Now, add the telescope to the site's telescopes
-            site['telescopes'].append(telescope)
+                # get the site dictionary from the facilities list of sites
+                # filter by site_code and provide a default (None) for new sites
+                site = next((site_ix for site_ix in facility_status['sites']
+                             if site_ix['code'] == site_code), None)
+                # create the site if it's new and not yet in the facility_status['sites] list
+                if site is None:
+                    new_site = {
+                        'code': site_code,
+                        'telescopes': []
+                    }
+                    facility_status['sites'].append(new_site)
+                    site = new_site
+
+                # Now, add the telescope to the site's telescopes
+                site['telescopes'].append(telescope)
 
         return facility_status
 

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -1252,7 +1252,7 @@ class LCOFacility(BaseRoboticObservationFacility):
 
         for telescope_key, telescope_value in telescope_states.items():
             [site_code, _, _] = telescope_key.split('.')
-            
+
             # limit returned sites to those provided by the facility
             if site_code in site_list:
 

--- a/tom_observations/facilities/soar.py
+++ b/tom_observations/facilities/soar.py
@@ -132,3 +132,7 @@ class SOARFacility(LCOFacility):
 
     def get_form(self, observation_type):
         return self.observation_forms.get(observation_type, SOARBaseObservationForm)
+
+    # Do not inherit facility status from LCOFacility to avoid duplicating the facility status list
+    def get_facility_status(self):
+        return {}

--- a/tom_observations/facilities/soar.py
+++ b/tom_observations/facilities/soar.py
@@ -133,6 +133,21 @@ class SOARFacility(LCOFacility):
     def get_form(self, observation_type):
         return self.observation_forms.get(observation_type, SOARBaseObservationForm)
 
-    # Do not inherit facility status from LCOFacility to avoid duplicating the facility status list
-    def get_facility_status(self):
-        return {}
+    def get_facility_weather_urls(self):
+        """
+        `facility_weather_urls = {'code': 'XYZ', 'sites': [ site_dict, ... ]}`
+        where
+        `site_dict = {'code': 'XYZ', 'weather_url': 'http://path/to/weather'}`
+        """
+        facility_weather_urls = {
+            'code': 'SOAR',
+            'sites': [
+                {
+                    'code': site['sitecode'],
+                    'weather_url': f'https://noirlab.edu/science/observing-noirlab/weather-webcams/'
+                                   f'cerro-pachon/environmental-conditions'
+                }
+                for site in self.SITES.values()]
+            }
+
+        return facility_weather_urls

--- a/tom_observations/facilities/soar.py
+++ b/tom_observations/facilities/soar.py
@@ -144,8 +144,8 @@ class SOARFacility(LCOFacility):
             'sites': [
                 {
                     'code': site['sitecode'],
-                    'weather_url': f'https://noirlab.edu/science/observing-noirlab/weather-webcams/'
-                                   f'cerro-pachon/environmental-conditions'
+                    'weather_url': 'https://noirlab.edu/science/observing-noirlab/weather-webcams/'
+                                   'cerro-pachon/environmental-conditions'
                 }
                 for site in self.SITES.values()]
             }


### PR DESCRIPTION
Right now the "facility status" tab on the target page lists every LCO site twice. This is because the `SOARFacility` inherits its `get_facility_status` method from `LCOFacility`, which gets the status of every LCO site from the scheduler. This fix just removes that inheritance so that each LCO site is only listed once (from `LCOFacility.get_facility_status`).