### PR TITLE
display only relevant visibility on observation form

### DIFF
--- a/tom_observations/templatetags/observation_extras.py
+++ b/tom_observations/templatetags/observation_extras.py
@@ -97,7 +97,7 @@ def facility_observation_form(target, facility, observation_type):
 
 
 @register.inclusion_tag('tom_observations/partials/observation_plan.html')
-def observation_plan(target, facility, length=7, interval=60, airmass_limit=None):
+def observation_plan(target, facility=None, length=7, interval=60, airmass_limit=None):
     """
     Displays form and renders plot for visibility calculation. Using this templatetag to render a plot requires that
     the context of the parent view have values for start_time, end_time, and airmass.
@@ -107,7 +107,7 @@ def observation_plan(target, facility, length=7, interval=60, airmass_limit=None
     start_time = datetime.now()
     end_time = start_time + timedelta(days=length)
 
-    visibility_data = get_sidereal_visibility(target, start_time, end_time, interval, airmass_limit)
+    visibility_data = get_sidereal_visibility(target, start_time, end_time, interval, airmass_limit, facility)
     i = 0
     plot_data = []
     for site, data in visibility_data.items():

--- a/tom_observations/utils.py
+++ b/tom_observations/utils.py
@@ -10,7 +10,7 @@ from tom_observations import facility
 logger = logging.getLogger(__name__)
 
 
-def get_sidereal_visibility(target, start_time, end_time, interval, airmass_limit):
+def get_sidereal_visibility(target, start_time, end_time, interval, airmass_limit, observation_facility=None):
     """
     Uses astroplan to calculate the airmass for a sidereal target
     for each given interval between the start and end times.
@@ -34,6 +34,9 @@ def get_sidereal_visibility(target, start_time, end_time, interval, airmass_limi
     :param airmass_limit: maximum acceptable airmass for the resulting calculations
     :type airmass_limit: int
 
+    :param observation_facility: observing facility for which to calculate the airmass. None indicates all available facilities.
+    :type observation_facility: BaseObservationFacility
+
     :returns: A dictionary containing the airmass data for each site. The dict keys consist of the site name prepended
         with the observing facility. The values are the airmass data, structured as an array containing two arrays. The
         first array contains the set of datetimes used in the airmass calculations. The second array contains the
@@ -53,11 +56,16 @@ def get_sidereal_visibility(target, start_time, end_time, interval, airmass_limi
     if airmass_limit is None:
         airmass_limit = 10
 
+    if observation_facility is None:
+        facilities = facility.get_service_classes()
+    else:
+        facilities = [observation_facility]
+
     body = FixedTarget(name=target.name, coord=SkyCoord(target.ra, target.dec, unit='deg'))
 
     visibility = {}
     sun, time_range = get_astroplan_sun_and_time(start_time, end_time, interval)
-    for observing_facility in facility.get_service_classes():
+    for observing_facility in facilities:
         observing_facility_class = facility.get_service_class(observing_facility)
         sites = observing_facility_class().get_observing_sites()
         for site, site_details in sites.items():

--- a/tom_observations/utils.py
+++ b/tom_observations/utils.py
@@ -35,7 +35,7 @@ def get_sidereal_visibility(target, start_time, end_time, interval, airmass_limi
     :type airmass_limit: int
 
     :param observation_facility: observing facility for which to calculate the airmass. None indicates all available
-    facilities.
+        facilities.
     :type observation_facility: BaseObservationFacility
 
     :returns: A dictionary containing the airmass data for each site. The dict keys consist of the site name prepended

--- a/tom_observations/utils.py
+++ b/tom_observations/utils.py
@@ -34,7 +34,8 @@ def get_sidereal_visibility(target, start_time, end_time, interval, airmass_limi
     :param airmass_limit: maximum acceptable airmass for the resulting calculations
     :type airmass_limit: int
 
-    :param observation_facility: observing facility for which to calculate the airmass. None indicates all available facilities.
+    :param observation_facility: observing facility for which to calculate the airmass. None indicates all available
+    facilities.
     :type observation_facility: BaseObservationFacility
 
     :returns: A dictionary containing the airmass data for each site. The dict keys consist of the site name prepended


### PR DESCRIPTION
Right now, the visibility chart on the observation form page shows the airmass for all available facilities. This quickly gets crowded, with all the LCO sites plus Gemini by default. Some of the sites (e.g., Chile) also overlap each other.

These changes restrict that chart to only plot the visibility for the facility for which you are requesting observations. The `observation_plan` function already had an argument `facility` that was not used (I assume this was the intention), which I just had to pipe through to `get_sidereal_visibility`. The default behavior of these functions has not been changed.