### PR TITLE
fix width of moon distance plot

### DIFF
--- a/tom_observations/templates/tom_observations/observation_form.html
+++ b/tom_observations/templates/tom_observations/observation_form.html
@@ -17,13 +17,9 @@
 {% endif %}
 <div class="row">
     <div class="col-md-6">
-        <div class="row">
-            {% target_data target %}
-        </div>
-        <div class="row">
-            Lunar Distance
-            {% moon_distance target %}
-        </div>
+        {% target_data target %}
+        <h4>Lunar Distance</h4>
+        {% moon_distance target width=None %}
     </div>
     <div class="col-md-6">
         <ul class="nav nav-tabs" id="tabs">


### PR DESCRIPTION
This is a minor fix to the observation form template so that the moon distance plot in the left column does not overlap with the right column. Screenshots (Firefox) below. I also confirmed that it now dynamically adjusts the width to the window size.

Before:
![before](https://user-images.githubusercontent.com/1976665/183159741-6544625a-6351-4cc7-97a6-1f3113a0b725.png)

After:
![after](https://user-images.githubusercontent.com/1976665/183159766-a8794063-fa64-47e4-8401-3c2e96f38a3b.png)


