### PR TITLE
Fix/test fails

### DIFF
--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -265,6 +265,8 @@ class Target(models.Model):
         Ensures that Target.name and all aliases of the target are unique. Called automatically on save.
         """
         super().validate_unique(*args, **kwargs)
+        print(self.aliases.all())
+        print("========================================================")
         for alias in self.aliases.all():
             if alias.name == self.name:
                 raise ValidationError('Target name and target aliases must be unique')

--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -265,11 +265,11 @@ class Target(models.Model):
         Ensures that Target.name and all aliases of the target are unique. Called automatically on save.
         """
         super().validate_unique(*args, **kwargs)
-        print(self.aliases.all())
-        print("========================================================")
-        for alias in self.aliases.all():
-            if alias.name == self.name:
-                raise ValidationError('Target name and target aliases must be unique')
+        # Alias Check only necessary when updating target existing target. Reverse relationships require Primary Key.
+        if self.pk:
+            for alias in self.aliases.all():
+                if alias.name == self.name:
+                    raise ValidationError('Target name and target aliases must be unique')
 
     def __str__(self):
         return str(self.name)

--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -269,7 +269,7 @@ class Target(models.Model):
         if self.pk:
             for alias in self.aliases.all():
                 if alias.name == self.name:
-                    raise ValidationError('Target name and target aliases must be unique')
+                    raise ValidationError('Target name and target aliases must be different')
 
     def __str__(self):
         return str(self.name)

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -495,6 +495,51 @@ class TestTargetUpdate(TestCase):
         self.assertTrue(self.target.targetextra_set.filter(key='redshift').exists())
         self.assertTrue(self.target.aliases.filter(name='testtargetname2').exists())
 
+    def test_invalid_alias_update(self):
+        self.form_data.update({
+            'targetextra_set-TOTAL_FORMS': 1,
+            'targetextra_set-INITIAL_FORMS': 0,
+            'targetextra_set-MIN_NUM_FORMS': 0,
+            'targetextra_set-MAX_NUM_FORMS': 1000,
+            'aliases-TOTAL_FORMS': 1,
+            'aliases-INITIAL_FORMS': 0,
+            'aliases-MIN_NUM_FORMS': 0,
+            'aliases-MAX_NUM_FORMS': 1000,
+            'aliases-0-name': 'testtarget'
+        })
+        # Try to add alias that is the same as target name (not allowed)
+        response = self.client.post(reverse('targets:update', kwargs={'pk': self.target.id}), data=self.form_data)
+        self.assertContains(response, 'Alias testtarget has a conflict with the primary name of the target')
+        # Show Alias was not saved
+        self.target.refresh_from_db()
+        self.assertFalse(self.target.aliases.filter(name='testtarget').exists())
+
+    def test_invalid_name_update(self):
+        self.form_data.update({
+            'targetextra_set-TOTAL_FORMS': 0,
+            'targetextra_set-INITIAL_FORMS': 0,
+            'targetextra_set-MIN_NUM_FORMS': 0,
+            'targetextra_set-MAX_NUM_FORMS': 1000,
+            'aliases-TOTAL_FORMS': 1,
+            'aliases-INITIAL_FORMS': 0,
+            'aliases-MIN_NUM_FORMS': 0,
+            'aliases-MAX_NUM_FORMS': 1000,
+            'aliases-0-name': 'testtargetname2'
+        })
+        # Set alias
+        self.client.post(reverse('targets:update', kwargs={'pk': self.target.id}), data=self.form_data)
+        self.target.refresh_from_db()
+        self.assertTrue(self.target.aliases.filter(name='testtargetname2').exists())
+        # Change name to same as alias (Not allowed)
+        self.form_data.update({
+            'name': 'testtargetname2',
+        })
+        response = self.client.post(reverse('targets:update', kwargs={'pk': self.target.id}), data=self.form_data)
+        self.assertContains(response, 'Target name and target aliases must be different')
+        # Show name change was unsuccessful
+        self.target.refresh_from_db()
+        self.assertTrue(self.target.name, 'testtarget')
+
 
 class TestTargetImport(TestCase):
     def setUp(self):


### PR DESCRIPTION
Closes issue #561.

This issue was cause by the target creation validation checking if the target name matched the linked aliases before either target or aliases were saved in the DB.

Specifically I added a check to see if a target had a primary Key before attempting to check for aliases, so this validation would only run during updates and not during creation.

We currently do not check for uniqueness of name/aliases during creation. 