### PR TITLE
Add a table to the DB for storing the source/destination of shared data

### DIFF
--- a/tom_alerts/models.py
+++ b/tom_alerts/models.py
@@ -33,3 +33,50 @@ class BrokerQuery(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class AlertStreamMessage(models.Model):
+    """
+    Class representing a streaming message containing data
+    :param topic: The destination or source of sharing for the message.
+    :type topic: str
+
+    :param message_id: An external message identifier that can be used to locate the message within the given topic.
+    :type message_id: str
+
+    :param date_shared: The date on which the message is shared. (Date created by default.)
+    :type date_shared: datetime
+
+    :param exchange_status: Whether this message was sent or received.
+    :type exchange_status: str
+    """
+
+    EXCHANGE_STATUS_CHOICES = (
+        ('published', 'Published'),
+        ('ingested', 'Ingested')
+    )
+
+    topic = models.CharField(
+        max_length=500,
+        verbose_name='Message Topic',
+        help_text='The destination or source of sharing for the message.'
+    )
+    message_id = models.CharField(
+        max_length=50,
+        verbose_name='Message ID',
+        help_text='An external message identifier that can be used to locate the message within the given topic.'
+    )
+    date_shared = models.DateTimeField(
+        auto_now_add=True,
+        verbose_name='Date Shared',
+        help_text='The date on which the message is shared. (Date created by default.)'
+    )
+    exchange_status = models.CharField(
+        max_length=10,
+        verbose_name='Exchange Status',
+        choices=EXCHANGE_STATUS_CHOICES,
+        help_text='Whether this message was sent or received.'
+    )
+
+    def __str__(self):
+        return f'Message {self.message_id} on {self.topic}.'

--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -12,6 +12,7 @@ from fits2image.conversions import fits_to_jpg
 from PIL import Image
 
 from tom_targets.models import Target
+from tom_alerts.models import AlertStreamMessage
 from tom_observations.models import ObservationRecord
 
 logger = logging.getLogger(__name__)
@@ -322,6 +323,9 @@ class ReducedDatum(models.Model):
                     }
     :type value: dict
 
+    :param message: Set of ``AlertStreamMessage`` objects this object is associated with.
+    :type message: ManyRelatedManager object
+
     """
 
     target = models.ForeignKey(Target, null=False, on_delete=models.CASCADE)
@@ -334,6 +338,7 @@ class ReducedDatum(models.Model):
     source_location = models.CharField(max_length=200, default='')
     timestamp = models.DateTimeField(null=False, blank=False, default=datetime.now, db_index=True)
     value = models.JSONField(null=False, blank=False)
+    message = models.ManyToManyField(AlertStreamMessage)
 
     class Meta:
         get_latest_by = ('timestamp',)


### PR DESCRIPTION
This is to allow a record to be kept for each `ReducedDatum` about how it was shared, or where it came from.