### PR TITLE
Fix the date field on the tns broker

### DIFF
--- a/tom_alerts/brokers/tns.py
+++ b/tom_alerts/brokers/tns.py
@@ -32,9 +32,9 @@ class TNSForm(GenericQueryForm):
     days_ago = forms.FloatField(required=False, min_value=0.,
                                 label='Discovered in the Last __ Days',
                                 help_text='Leave blank to use the "Discovered After" field')
-    min_date = forms.DateTimeField(required=False,
-                                   label='Discovered After',
-                                   help_text='Most valid date formats are recognized')
+    min_date = forms.CharField(required=False,
+                               label='Discovered After',
+                               help_text='Most valid date formats are recognized')
     days_from_nondet = forms.FloatField(required=False, min_value=0.,
                                         label='Days From Nondetection',
                                         help_text='Maximum time between last nondetection and first detection')
@@ -106,7 +106,7 @@ class TNSBroker(GenericBroker):
             public_timestamp = (datetime.utcnow() - timedelta(days=parameters['days_ago']))\
                 .strftime('%Y-%m-%d %H:%M:%S')
         elif parameters['min_date'] is not None:
-            public_timestamp = parameters['min_date'].strftime('%Y-%m-%d %H:%M:%S')
+            public_timestamp = parameters['min_date']
         else:
             public_timestamp = ''
         data = {


### PR DESCRIPTION
Can't use a DateTimeField since we are storing the parameters in a JSONField and datetimes are not json serializable. Just a string date makes more sense anyway since we pass it through to TNS and they can interpret it how they want.