### PR TITLE
Feature/open outside links in new tabs

### DIFF
--- a/tom_alerts/brokers/alerce.py
+++ b/tom_alerts/brokers/alerce.py
@@ -132,8 +132,8 @@ class ALeRCEQueryForm(GenericQueryForm):
         self.helper.layout = Layout(
             HTML('''
                 <p>
-                Please see the <a href="http://alerce.science/">ALeRCE homepage</a> for information about the ALeRCE
-                filters.
+                Please see the <a href="http://alerce.science/" target="_blank">ALeRCE homepage</a> for information
+                about the ALeRCE filters.
             '''),
             self.common_layout,
             'oid',

--- a/tom_alerts/brokers/antares.py
+++ b/tom_alerts/brokers/antares.py
@@ -11,7 +11,7 @@ class ANTARESQueryForm(GenericQueryForm):
             HTML('''
                 <p>
                 This plugin is a stub for the ANTARES plugin. In order to install the full plugin, please see the
-                instructions <a href="https://github.com/TOMToolkit/tom_antares">here</a>.
+                instructions <a href="https://github.com/TOMToolkit/tom_antares" target="_blank">here</a>.
                 </p>
             '''),
             HTML('''<a class="btn btn-outline-primary" href={% url 'tom_alerts:list' %}>Back</a>''')

--- a/tom_alerts/brokers/gaia.py
+++ b/tom_alerts/brokers/gaia.py
@@ -30,8 +30,8 @@ class GaiaQueryForm(GenericQueryForm):
         self.helper.layout = Layout(
             HTML('''
                 <p>
-                Please see the <a href="http://gsaweb.ast.cam.ac.uk/alerts/tableinfo">Gaia homepage</a> for a detailed
-                description of this broker.
+                Please see the <a href="http://gsaweb.ast.cam.ac.uk/alerts/tableinfo" target="_blank">Gaia homepage</a>
+                for a detailed description of this broker.
             '''),
             self.common_layout,
             Fieldset(

--- a/tom_alerts/brokers/hermes.py
+++ b/tom_alerts/brokers/hermes.py
@@ -11,7 +11,7 @@ class HermesQueryForm(GenericQueryForm):
             HTML('''
                 <p>
                 This plugin is a stub for the Hermes Broker plugin. In order to install the full plugin, please see the
-                instructions <a href="https://github.com/TOMToolkit/tom_hermes">here</a>.
+                instructions <a href="https://github.com/TOMToolkit/tom_hermes" target="_blank">here</a>.
                 </p>
             '''),
             HTML('''<a class="btn btn-outline-primary" href={% url 'tom_alerts:list' %}>Back</a>''')

--- a/tom_alerts/brokers/lasair.py
+++ b/tom_alerts/brokers/lasair.py
@@ -27,8 +27,8 @@ class LasairBrokerForm(GenericQueryForm):
         self.helper.layout = Layout(
             HTML('''
                     <p>
-                    Please see the <a href="https://lasair-ztf.lsst.ac.uk/api">Lasair website</a> for more detailed
-                    instructions on querying the broker.
+                    Please see the <a href="https://lasair-ztf.lsst.ac.uk/api" target="_blank">Lasair website</a> for
+                    more detailed instructions on querying the broker.
                 '''),
             self.common_layout,
             Fieldset(

--- a/tom_alerts/brokers/scout.py
+++ b/tom_alerts/brokers/scout.py
@@ -18,8 +18,8 @@ class ScoutQueryForm(GenericQueryForm):
         self.helper.layout = Layout(
             HTML('''
                 <p>
-                Please see the <a href="https://ssd-api.jpl.nasa.gov/doc/scout.html">Scout API Reference</a>
-                for a detailed description of the service.
+                Please see the <a href="https://ssd-api.jpl.nasa.gov/doc/scout.html target="_blank"">Scout API
+                Reference</a> for a detailed description of the service.
                 </p>
             '''),
             self.common_layout,

--- a/tom_alerts/brokers/tns.py
+++ b/tom_alerts/brokers/tns.py
@@ -44,8 +44,8 @@ class TNSForm(GenericQueryForm):
         self.helper.layout = Layout(
             HTML('''
                 <p>
-                Please see <a href="https://wis-tns.weizmann.ac.il/sites/default/files/api/TNS_APIs_manual.pdf">
-                the TNS API Manual</a> for a detailed description of available filters.
+                Please see <a href="https://wis-tns.weizmann.ac.il/sites/default/files/api/TNS_APIs_manual.pdf"
+                target="_blank">the TNS API Manual</a> for a detailed description of available filters.
                 </p>
             '''),
             self.common_layout,

--- a/tom_common/templates/tom_common/index.html
+++ b/tom_common/templates/tom_common/index.html
@@ -9,7 +9,7 @@
     <h3>Next steps</h3>
     <ul>
       <li>
-        Check out the <a href="https://tom-toolkit.readthedocs.io/en/stable/" title="TOM Toolkit home page">TOM
+        Check out the <a href="https://tom-toolkit.readthedocs.io/en/stable/" title="TOM Toolkit home page" target="_blank">TOM
         Toolkit homepage</a> for the latest news, downloads and documentation.
       </li>
       <li>
@@ -21,13 +21,13 @@
         project's <code>urls.py</code>.
       </li>
       <li>
-        Take a look at some <a href="https://tom-toolkit.readthedocs.io/en/stable/customization/index.html">common first customizations</a>.
+        Take a look at some <a href="https://tom-toolkit.readthedocs.io/en/stable/customization/index.html" target="_blank">common first customizations</a>.
       </li>
     </ul>
     <h3>Other Resources</h3>
     <ul>
-      <li>The official <a href="https://www.djangoproject.com/">Django documentation</a>.</li>
-      <li>The official <a href="http://www.astropy.org/">Astropy documentation</a>.</li>
+      <li>The official <a href="https://www.djangoproject.com/" target="_blank">Django documentation</a>.</li>
+      <li>The official <a href="http://www.astropy.org/" target="_blank">Astropy documentation</a>.</li>
     </ul>
   </div>
   <div class="col-md-4">

--- a/tom_observations/facilities/lco.py
+++ b/tom_observations/facilities/lco.py
@@ -30,27 +30,27 @@ class LCOSettings(OCSSettings):
     # Override them as desired for a specific OCS implementation.
     end_help = """
         Try the
-        <a href="https://lco.global/observatory/visibility/">
+        <a href="https://lco.global/observatory/visibility/" target="_blank">
             Target Visibility Calculator.
         </a>
     """
 
     instrument_type_help = """
-        <a href="https://lco.global/observatory/instruments/">
+        <a href="https://lco.global/observatory/instruments/" target="_blank">
             More information about LCO instruments.
         </a>
     """
 
     max_airmass_help = """
         Advice on
-        <a href="https://lco.global/documentation/airmass-limit">
+        <a href="https://lco.global/documentation/airmass-limit" target="_blank">
             setting the airmass limit.
         </a>
     """
 
     exposure_time_help = """
         Try the
-        <a href="https://exposure-time-calculator.lco.global/">
+        <a href="https://exposure-time-calculator.lco.global/" target="_blank">
             online Exposure Time Calculator.
         </a>
     """
@@ -75,7 +75,7 @@ class LCOSettings(OCSSettings):
     static_cadencing_help = """
         <em>Static cadence parameters.</em> Leave blank if no cadencing is desired.
         For information on static cadencing with LCO,
-        <a href="https://lco.global/documentation/">
+        <a href="https://lco.global/documentation/" target="_blank">
             check the Observation Portal getting started guide, starting on page 27.
         </a>
     """

--- a/tom_observations/facilities/lt.py
+++ b/tom_observations/facilities/lt.py
@@ -12,7 +12,7 @@ class LTQueryForm(GenericObservationForm):
             HTML('''
                 <p>
                 This plugin is a stub for the Liverpool Telescope plugin. In order to install the full plugin, please
-                see the instructions <a href="https://github.com/TOMToolkit/tom_lt">here</a>.
+                see the instructions <a href="https://github.com/TOMToolkit/tom_lt" target="_blank">here</a>.
                 </p>
             '''),
             HTML(f'''<a class="btn btn-outline-primary" href={{% url 'tom_targets:detail' {target_id} %}}>Back</a>''')

--- a/tom_observations/facilities/ocs.py
+++ b/tom_observations/facilities/ocs.py
@@ -36,13 +36,13 @@ class OCSSettings():
     # Override them as desired for a specific OCS implementation.
     ipp_value_help = """
             Value between 0.5 to 2.0.
-            <a href="https://lco.global/documents/20/the_new_priority_factor.pdf">
+            <a href="https://lco.global/documents/20/the_new_priority_factor.pdf" target="_blank">
                 More information about Intra Proprosal Priority (IPP).
             </a>
     """
 
     observation_mode_help = """
-        <a href="https://lco.global/documentation/special-scheduling-modes/">
+        <a href="https://lco.global/documentation/special-scheduling-modes/" target="_blank">
             More information about Rapid Response mode.
         </a>
     """

--- a/tom_observations/templates/tom_observations/partials/facility_status.html
+++ b/tom_observations/templates/tom_observations/partials/facility_status.html
@@ -19,7 +19,7 @@
               <td>{{ site.code }}</td>
               <td>{{ telescope.code }}</td>
               <td>{{ telescope.status }}</td>
-              <td><a href="{{ site.weather_url }}">link</a></td>
+              <td><a href="{{ site.weather_url }}" target="_blank">link</a></td>
           </tr>
         {% endfor %}
         {% endfor %}


### PR DESCRIPTION
This PR changes all of the external links I could find to open in a new tab so as to not derail a users TOM experience.

Specifically, these changes affect:

- Links to Alert Brokers
- Home Page Links
- Facility links for additional info when making observing requests
- Links to site weather information
