### PR TITLE
remove reliance on alerce page return

### DIFF
--- a/tom_alerts/brokers/alerce.py
+++ b/tom_alerts/brokers/alerce.py
@@ -314,12 +314,19 @@ class ALeRCEBroker(GenericBroker):
         return response.json()
 
     def fetch_alerts(self, parameters):
+        """
+        Loop through pages of ALeRCE alerts until we reach the maximum pages requested.
+        This simply concatenates all alerts from n pages into a single iterable to be returned.
+        """
         response = self._request_alerts(parameters)
         alerts = response['items']
         broker_feedback = ''
-        if len(alerts) > 0 and parameters.get('page', 1) < parameters.get('max_pages', 1):
-            parameters['page'] = parameters.get('page', 1) + 1
+        current_page = parameters.get('page', 1)
+        if len(alerts) > 0 and current_page < parameters.get('max_pages', 1):
+            # make new request for the next page. (by recursion)
+            parameters['page'] = current_page + 1
             alerts += self.fetch_alerts(parameters)[0]
+        # Bottom out of recursion and return accumulated alerts
         return iter(alerts), broker_feedback
 
     def fetch_alert(self, id):

--- a/tom_alerts/brokers/alerce.py
+++ b/tom_alerts/brokers/alerce.py
@@ -308,7 +308,7 @@ class ALeRCEBroker(GenericBroker):
     def _request_alerts(self, parameters):
         payload = self._clean_parameters(parameters)
         logger.log(msg=f'Fetching alerts from ALeRCE with payload {payload}', level=logging.INFO)
-        args = urlencode(self._clean_parameters(parameters))
+        args = urlencode(payload)
         response = requests.get(f'{ALERCE_SEARCH_URL}/objects/?count=false&{args}')
         response.raise_for_status()
         return response.json()
@@ -317,8 +317,8 @@ class ALeRCEBroker(GenericBroker):
         response = self._request_alerts(parameters)
         alerts = response['items']
         broker_feedback = ''
-        if len(alerts) > 0 and response['page'] < parameters.get('max_pages', 1):
-            parameters['page'] = response.get('page') + 1
+        if len(alerts) > 0 and parameters.get('page', 1) < parameters.get('max_pages', 1):
+            parameters['page'] = parameters.get('page', 1) + 1
             alerts += self.fetch_alerts(parameters)[0]
         return iter(alerts), broker_feedback
 


### PR DESCRIPTION
This change removes the reliance on the `page` key being returned successfully from the broker. We rely entirely on our own pagination count.
This Key is returned `null` for all requests from [ALeRCE](https://api.alerce.online/ztf/v1). 