### PR TITLE
Clarify sidereal vs non-sidereal setup prompt

### DIFF
--- a/tom_setup/management/commands/tom_setup.py
+++ b/tom_setup/management/commands/tom_setup.py
@@ -88,7 +88,7 @@ class Command(BaseCommand):
             '2': 'NON_SIDEREAL'
         }
         options_str = ['{}) {}'.format(key, target_type) for key, target_type in allowed_types.items()]
-        prompt = 'Which target type will your project use? {} '.format(self.style.WARNING(", ".join(options_str)))
+        prompt = 'Which target type should be used as default? {} '.format(self.style.WARNING(", ".join(options_str)))
         target_type = input(prompt)
         try:
             self.context['TARGET_TYPE'] = allowed_types[target_type]


### PR DESCRIPTION
This simply clarifies the the purpose of the confusing set-up question.
I think another solution would be to remove the question, set the default key in `settings.py` to sidereal, and edit the docs and add a comment to `settings.py` to let users know that they can set this value to "non-sidereal" if they want that to be the default form that comes up first when creating new targets.