### PR TITLE
Add ability to navaigate to specific tab in target view.

### DIFF
--- a/tom_observations/templates/tom_observations/partials/observation_list.html
+++ b/tom_observations/templates/tom_observations/partials/observation_list.html
@@ -1,9 +1,10 @@
 <table class="table table-striped">
-  <thead><tr><th>Facility</th><th>Created</th><th>Status</th><th>Scheduled</th><th>Saved  data</th><th>View</th></tr></thead>
+  <thead><tr><th>Facility</th><th>Observation ID</th><th>Created</th><th>Status</th><th>Scheduled</th><th>Saved  data</th><th>View</th></tr></thead>
   <tbody>
   {% for observation in observations %}
     <tr>
       <td>{{ observation.facility }}</td>
+      <td>{{ observation.observation_id }}</td>
       <td>{{ observation.created }}</td>
       <td>{{ observation.status }}</td>
       <td>{{ observation.scheduled_start }}</td>

--- a/tom_observations/templates/tom_observations/partials/observation_list.html
+++ b/tom_observations/templates/tom_observations/partials/observation_list.html
@@ -4,7 +4,11 @@
   {% for observation in observations %}
     <tr>
       <td>{{ observation.facility }}</td>
-      <td>{{ observation.observation_id }}</td>
+      {% if observation.url %}
+        <td><a href="{{ observation.url }}">{{ observation.observation_id }}</a></td>
+      {% else %}
+        <td>{{ observation.observation_id }}</td>
+      {% endif %}
       <td>{{ observation.created }}</td>
       <td>{{ observation.status }}</td>
       <td>{{ observation.scheduled_start }}</td>

--- a/tom_observations/views.py
+++ b/tom_observations/views.py
@@ -467,9 +467,9 @@ class AddExistingObservationView(LoginRequiredMixin, FormView):
             )
             observation_id = form.cleaned_data['observation_id']
             messages.success(self.request, f'Successfully associated observation record {observation_id}')
-        return redirect(reverse(
-            'tom_targets:detail', kwargs={'pk': form.cleaned_data['target_id']})
-        )
+        base_url = reverse('tom_targets:detail', kwargs={'pk': form.cleaned_data['target_id']})
+        query_params = urlencode({'tab': 'observations'})
+        return redirect(f'{base_url}?{query_params}')
 
 
 class ObservationRecordDetailView(DetailView):

--- a/tom_targets/templates/tom_targets/target_detail.html
+++ b/tom_targets/templates/tom_targets/target_detail.html
@@ -7,18 +7,24 @@
 {% endblock %}
 {% block content %}
 <script>
-// This script maintains the selected tab upon reload
-$(document).ready(function(){
-  // This is required due to the apparent redefinition of $ in another library: https://api.jquery.com/jquery.noconflict/
-  // Based on trial and error, the offending script appears to be JS9, which is used in dataproduct_list_for_target
-  $.noConflict();
-  $('a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
-    localStorage.setItem('activeTab', $(e.target).attr('href'));
-  });
+document.addEventListener("DOMContentLoaded", function() {
+  // Fetch the URL and look for the 'tab' query parameter.
+  const url = new URL(window.location.href);
+  const tabQuery = url.searchParams.get('tab');
 
-  var activeTab = localStorage.getItem('activeTab');
-  if(activeTab){
-    $('#tabs a[href="' + activeTab + '"]').tab('show');
+  // If a tab is specified in the URL, make it active.
+  if (tabQuery) {
+    const activeTab = '#' + tabQuery;
+    // Remove the 'tab' query parameter to avoid unwanted persistence across
+    // page reloads.
+    url.searchParams.delete('tab');
+    history.replaceState({}, document.title, url.toString());
+
+    // Show the active tab, if any.
+    const tabElement = document.querySelector(`a[href="${activeTab}"]`);
+    if (tabElement) {
+      tabElement.click();
+    }
   }
 });
 </script>
@@ -39,7 +45,7 @@ $(document).ready(function(){
       {% if object.type == 'SIDEREAL' %}
       {% aladin object %}
       {% endif %}
-      
+
     </div>
   </div>
   <div class="col-md-8">

--- a/tom_targets/templates/tom_targets/target_detail.html
+++ b/tom_targets/templates/tom_targets/target_detail.html
@@ -7,26 +7,31 @@
 {% endblock %}
 {% block content %}
 <script>
-document.addEventListener("DOMContentLoaded", function() {
-  // Fetch the URL and look for the 'tab' query parameter.
-  const url = new URL(window.location.href);
-  const tabQuery = url.searchParams.get('tab');
-
-  // If a tab is specified in the URL, make it active.
-  if (tabQuery) {
-    const activeTab = '#' + tabQuery;
-    // Remove the 'tab' query parameter to avoid unwanted persistence across
-    // page reloads.
-    url.searchParams.delete('tab');
+  // Function to update the URL.
+  const updateUrlWithTab = (tabId) => {
+    const url = new URL(window.location.href);
+    url.searchParams.set('tab', tabId);
     history.replaceState({}, document.title, url.toString());
+  };
 
-    // Show the active tab, if any.
-    const tabElement = document.querySelector(`a[href="${activeTab}"]`);
-    if (tabElement) {
-      tabElement.click();
+  document.addEventListener("DOMContentLoaded", function() {
+    // Listen for tab changes.
+    document.querySelectorAll('#tabs .nav-link').forEach(tab => {
+      tab.addEventListener('click', function() {
+        updateUrlWithTab(this.id.replace('-tab', ''));
+      });
+    });
+
+    // Initial tab selection from URL.
+    const tabQuery = new URL(window.location.href).searchParams.get('tab');
+    if (tabQuery) {
+      const activeTab = '#' + tabQuery;
+      const tabElement = document.querySelector(`a[href="${activeTab}"]`);
+      if (tabElement) {
+        tabElement.click();
+      }
     }
-  }
-});
+  });
 </script>
 <div class="row">
   <div class="col-md-4">

--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -435,7 +435,7 @@ class TargetDetailView(Raise403PermissionRequiredMixin, DetailView):
                               'Did you know updating observation statuses can be automated? Learn how in'
                               '<a href=https://tom-toolkit.readthedocs.io/en/stable/customization/automation.html>'
                               ' the docs.</a>'))
-            return redirect(reverse('tom_targets:detail', args=(target_id,)))
+            return redirect(reverse('tom_targets:detail', args=(target_id,)) + '?tab=observations')
 
         obs_template_form = ApplyObservationTemplateForm(request.GET)
         if obs_template_form.is_valid():


### PR DESCRIPTION
Resolves Issue #697.

1. Introduces URL parameter support for directly navigating to specific tabs in the target detail view (e.g., `/targets/1/?tab=observations`). Initial implementation is limited to two sections that our users found most impactful but could be applied anywhere the directs to the target detail view. This was written with vanilla javascript, removing the concern of Jquery conflicts. 
  
2. Augments `observation_list.html` to display observation IDs, improving user experience to trace data to what ID in the overview.

