### PR TITLE
add the newly required build section to readthedocs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,13 @@
 # Required
 version: 2
 
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -18,7 +25,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3.11
   install:
     - method: pip
       path: .


### PR DESCRIPTION
We've been encountering this error on our recent documentation builds:
```Problem in your project's configuration. Invalid configuration option "build.os": build not found```

The new `build` section of the config file supplies the `build.os` configuration option that they're complaining about.
Here's where they explained the change: https://blog.readthedocs.com/migrate-configuration-v2/