### PR TITLE
remove special behavior for single target creation

### DIFF
--- a/tom_alerts/tests/tests.py
+++ b/tom_alerts/tests/tests.py
@@ -228,7 +228,7 @@ class TestBrokerViews(TestCase):
         response = self.client.post(reverse('tom_alerts:create-target'), data=post_data)
         self.assertEqual(Target.objects.count(), 1)
         self.assertEqual(Target.objects.first().name, 'Hoth')
-        self.assertRedirects(response, reverse('tom_targets:update', kwargs={'pk': Target.objects.first().id}))
+        self.assertRedirects(response, reverse('tom_targets:list'))
 
     @override_settings(CACHES={
             'default': {

--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -300,16 +300,9 @@ class CreateTargetFromAlertView(LoginRequiredMixin, View):
             except IntegrityError:
                 messages.warning(request, f'Unable to save {target.name}, target with that name already exists.')
                 errors.append(target.name)
-        if (len(alerts) == len(errors)):
+        if len(alerts) == len(errors):
             return redirect(reverse('tom_alerts:run', kwargs={'pk': query_id}))
-        elif (len(alerts) == 1):
-            return redirect(reverse(
-                'tom_targets:update', kwargs={'pk': target.id})
-            )
-        else:
-            return redirect(reverse(
-                'tom_targets:list')
-            )
+        return redirect(reverse('tom_targets:list'))
 
 
 class SubmitAlertUpstreamView(LoginRequiredMixin, FormMixin, ProcessFormView, View):


### PR DESCRIPTION
Currently when a single target is ingested from a broker, it redirects to the target update page. This is awkward and a request has been made by users to default this to the target list page to be the same as having multiple targets ingested.