### PR TITLE
Thumbnails fail if your FITS file isn't square

### DIFF
--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -234,8 +234,9 @@ class DataProduct(models.Model):
         """
         if self.thumbnail:
             im = Image.open(self.thumbnail)
-            if im.size != THUMBNAIL_DEFAULT_SIZE:
+            if im.size != THUMBNAIL_DEFAULT_SIZE and im.size[0] not in THUMBNAIL_DEFAULT_SIZE:
                 redraw = True
+                logger.critical("Redrawing thumbnail for {0} due to size mismatch".format(im.size))
 
         if not self.thumbnail or redraw:
             width, height = THUMBNAIL_DEFAULT_SIZE
@@ -262,6 +263,9 @@ class DataProduct(models.Model):
         :returns: Thumbnail file if created, None otherwise
         :rtype: file
         """
+        if not self.data:
+            logger.error(f'Unable to create thumbnail for {self}: No data file found.')
+            return
         if is_fits_image_file(self.data.file):
             tmpfile = tempfile.NamedTemporaryFile(suffix='.jpg')
             try:


### PR DESCRIPTION
Because of this line in [tom_dataproducts/models.py]( https://github.com/TOMToolkit/tom_base/blob/bbdef40be15cc6cd9dab5db2b04c82c6c7692025/tom_dataproducts/models.py#L237) if your FITS file image dimensions are not 1:1 the thumbnail will always be regenerated. 

I've put in a check that one of the axes fits into the default size i.e.
```
if im.size != THUMBNAIL_DEFAULT_SIZE and im.size[0] not in THUMBNAIL_DEFAULT_SIZE:
```
Its not a perfect solution but I think its better than the current situation. I could imagine making the `THUMBNAIL_DEFAULT_SIZE` is list of defaults but that would  have a much bigger impact on the code base and not be backwards compatible.