### PR TITLE
Bugfix: Typo in btn class html.

### DIFF
--- a/tom_dataproducts/templates/tom_dataproducts/partials/saved_dataproduct_list_for_observation.html
+++ b/tom_dataproducts/templates/tom_dataproducts/partials/saved_dataproduct_list_for_observation.html
@@ -21,7 +21,7 @@
         {% endif %}
       </a></td>
       <td>{{ product.created }}</td>
-      <td><a href="{% url 'tom_dataproducts:delete' product.id %}" class="btnbtn-danger">Delete</a></td>
+      <td><a href="{% url 'tom_dataproducts:delete' product.id %}" class="btn btn-danger">Delete</a></td>
     </tr>
     {% empty %}
     <tr>


### PR DESCRIPTION
A small bugfix addressing the missing space between `btn btn-danger` class. 