### PR TITLE
remove bootstrap_css load in forced photometry html

### DIFF
--- a/tom_dataproducts/templates/tom_dataproducts/partials/query_forced_photometry.html
+++ b/tom_dataproducts/templates/tom_dataproducts/partials/query_forced_photometry.html
@@ -5,4 +5,6 @@
 <h4>Query Forced Photometry Service</h4>
 {% for service in forced_photometry_services %}
 <a href="{% url 'tom_dataproducts:forced-photometry-query' service=service %}?target_id={{ target.id }}" title="{{ service }}" class="btn btn-outline-primary">{{ service }}</a>
+{% empty %}
+No forced photometry services are configured. See the <a href="https://tom-toolkit.readthedocs.io/en/latest/managing_data/forced_photometry.html" target="_blank">TOM documentation</a> for more information.
 {% endfor %}

--- a/tom_dataproducts/templates/tom_dataproducts/partials/query_forced_photometry.html
+++ b/tom_dataproducts/templates/tom_dataproducts/partials/query_forced_photometry.html
@@ -1,5 +1,4 @@
 {% load bootstrap4 static %}
-{% bootstrap_css %}
 {% bootstrap_javascript jquery='full' %}
 <script src="{% static 'assets/js/popper.min.js' %}"></script>
 <script src="{% static 'js/jquery.bootstrap.modal.forms.js' %}"></script>

--- a/tom_dataproducts/templates/tom_dataproducts/partials/query_forced_photometry.html
+++ b/tom_dataproducts/templates/tom_dataproducts/partials/query_forced_photometry.html
@@ -1,7 +1,3 @@
-{% load bootstrap4 static %}
-{% bootstrap_javascript jquery='full' %}
-<script src="{% static 'assets/js/popper.min.js' %}"></script>
-<script src="{% static 'js/jquery.bootstrap.modal.forms.js' %}"></script>
 <h4>Query Forced Photometry Service</h4>
 {% for service in forced_photometry_services %}
 <a href="{% url 'tom_dataproducts:forced-photometry-query' service=service %}?target_id={{ target.id }}" title="{{ service }}" class="btn btn-outline-primary">{{ service }}</a>


### PR DESCRIPTION
I don't have a ton of experience with the forced photometry stuff.
I just want to make sure this doesn't break anything major before implementing it.

This removes the `bootstrap_css` so it doesn't overwrite the regular CSS from `base.html`.

I also snuck in a message about how to configure forced photometry in case none were currently available.