### PR TITLE
only show unknown status warning if there are any

### DIFF
--- a/tom_targets/templates/tom_targets/partials/target_unknown_statuses.html
+++ b/tom_targets/templates/tom_targets/partials/target_unknown_statuses.html
@@ -1,3 +1,5 @@
-<div class="alert alert-warning">
+{% if num_unknown_statuses %}
+  <div class="alert alert-warning">
     There are {{ num_unknown_statuses }} observations with unknown status.
   </div>
+{% endif %}


### PR DESCRIPTION
This is a very small change that hides the yellow "observations with unknown status" warning at the top of every target page unless there is actually an observation request with unknown status. Currently, I find myself ignoring that message because it appears at the top of every page, so I hope this will make it more useful. This makes it match the behavior of the green "upcoming observations" message, which only appears if there are pending observations.