### PR TITLE
Add Override for data Product path so user can define whatever path they like

### DIFF
--- a/docs/managing_data/customizing_data_processing.rst
+++ b/docs/managing_data/customizing_data_processing.rst
@@ -57,11 +57,10 @@ you wanted to set the `data_product_path` to ``{target}/{facility}/{observation_
 .. code:: python
 
    def custom_data_product_path(data_product, filename):
-       return '{}/{}/{}/{}'.format(data_product.target.name,
-                                   data_product.observation_record.facility,
-                                   data_product.observation_record.observation_id,
-                                   filename)
-
+       return f'{data_product.target.name}/' \
+               f'{data_product.observation_record.facility}/' \
+               f'{data_product.observation_record.observation_id}/' \
+               f'{filename}'
 
 All data products are automatically “processed” on upload, as well. Of
 course, that can mean different things to different TOMs! The TOM has

--- a/docs/managing_data/customizing_data_processing.rst
+++ b/docs/managing_data/customizing_data_processing.rst
@@ -48,6 +48,21 @@ In order to add new data product types, simply add a new key/value pair,
 with the value being a 2-tuple. The first tuple item is the database
 value, and the second is the display value.
 
+When a ``DataProduct`` is uploaded, its path is set by a `data_product_path`. By default this is set to
+``{target}/{facility}/{filename}``, but can be overridden by setting the ``DATA_PRODUCT_PATH`` in
+``settings.py`` to a dot-separated method path that takes a ``DataProduct`` and filename as arguments. For example, if
+you wanted to set the `data_product_path` to ``{target}/{facility}/{observation_id}/{filename}``, you would point the
+``DATA_PRODUCT_PATH`` to a custom method that looks something like this:
+
+.. code:: python
+
+   def custom_data_product_path(data_product, filename):
+       return '{}/{}/{}/{}'.format(data_product.target.name,
+                                   data_product.observation_record.facility,
+                                   data_product.observation_record.observation_id,
+                                   filename)
+
+
 All data products are automatically “processed” on upload, as well. Of
 course, that can mean different things to different TOMs! The TOM has
 two built-in data processors, both of which simply ingest the data into

--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -100,7 +100,7 @@ def data_product_path(instance, filename):
             mod = import_module(mod_name)
             clazz = getattr(mod, class_name)
         except (ImportError, AttributeError):
-            raise ImportError('Could not import {}. Did you provide the correct path?'.format(processor_class))
+            raise ImportError('Could not import {}. Did you provide the correct path?'.format(path_class))
         return clazz(instance, filename)
     except AttributeError:
         # Uploads go to MEDIA_ROOT

--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -100,14 +100,14 @@ def data_product_path(instance, filename):
             mod = import_module(mod_name)
             clazz = getattr(mod, class_name)
         except (ImportError, AttributeError):
-            raise ImportError('Could not import {}. Did you provide the correct path?'.format(path_class))
+            raise ImportError(f'Could not import {path_class}. Did you provide the correct path?')
         return clazz(instance, filename)
     except AttributeError:
         # Uploads go to MEDIA_ROOT
         if instance.observation_record is not None:
-            return '{0}/{1}/{2}'.format(instance.target.name, instance.observation_record.facility, filename)
+            return f'{instance.target.name}/{instance.observation_record.facility}/{filename}'
         else:
-            return '{0}/none/{1}'.format(instance.target.name, filename)
+            return f'{instance.target.name}/none/{filename}'
 
 
 class DataProductGroup(models.Model):

--- a/tom_dataproducts/tests/tests.py
+++ b/tom_dataproducts/tests/tests.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 
 from tom_dataproducts.exceptions import InvalidFileFormatException
 from tom_dataproducts.forms import DataProductUploadForm
-from tom_dataproducts.models import DataProduct, is_fits_image_file, ReducedDatum
+from tom_dataproducts.models import DataProduct, is_fits_image_file, ReducedDatum, data_product_path
 from tom_dataproducts.processors.data_serializers import SpectrumSerializer
 from tom_dataproducts.processors.photometry_processor import PhotometryProcessor
 from tom_dataproducts.processors.spectroscopy_processor import SpectroscopyProcessor
@@ -38,6 +38,10 @@ def mock_find_fits_img_size(filename):
 
 def mock_is_fits_image_file(filename):
     return True
+
+
+def dp_path(instance, filename):
+    return f'new_path/{filename}'
 
 
 @override_settings(TOM_FACILITY_CLASSES=['tom_observations.tests.utils.FakeRoboticFacility'],
@@ -142,6 +146,35 @@ class Views(TestCase):
         self.assertTrue(resp)
         products = DataProduct.objects.filter(data_product_type='image_file')
         self.assertEqual(products.count(), 1)
+
+
+class TestModels(TestCase):
+    def setUp(self):
+        self.overide_path = 'tom_dataproducts.tests.tests.dp_path'
+        self.target = SiderealTargetFactory.create()
+        self.observation_record = ObservingRecordFactory.create(
+            target_id=self.target.id,
+            facility=FakeRoboticFacility.name,
+            parameters={}
+        )
+        self.data_product = DataProduct.objects.create(
+            product_id='testproductid',
+            target=self.target,
+            observation_record=self.observation_record,
+            data=SimpleUploadedFile('afile.fits', b'somedata')
+        )
+
+    def test_no_path_overide(self):
+        """Test that the default path is used if no overide is set"""
+        filename = 'afile.fits'
+        path = data_product_path(self.data_product, filename)
+        self.assertIn(f'FakeRoboticFacility/{filename}', path)
+
+    @override_settings(DATA_PRODUCT_PATH='tom_dataproducts.tests.tests.dp_path')
+    def test_path_overide(self):
+        """Test that the overide path is used if set"""
+        path = data_product_path(self.data_product, 'afile.fits')
+        self.assertIn('new_path/afile.fits', path)
 
 
 @override_settings(TOM_FACILITY_CLASSES=['tom_observations.tests.utils.FakeRoboticFacility'],


### PR DESCRIPTION
This should allow a user to add a `DATA_PRODUCT_PATH` value to their `settings.py` allowing for them to override the default path creation method for Data Products.