### PR TITLE
Fix Incorrect Time Format in `DATETIME_FORMAT` Setting

### DIFF
--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -151,7 +151,7 @@ USE_L10N = False
 
 USE_TZ = True
 
-DATETIME_FORMAT = 'Y-m-d H:m:s'
+DATETIME_FORMAT = 'Y-m-d H:i:s'
 DATE_FORMAT = 'Y-m-d'
 
 


### PR DESCRIPTION
This PR updates the `DATETIME_FORMAT` setting to correct a bug that caused the wrong time to be displayed in our application.

Previously, the DATETIME_FORMAT was set as:

```python
DATETIME_FORMAT = 'Y-m-d H:m:s'
```

However, this format string incorrectly used `m` (month) in the place where `i` (minute) should have been used. 

The corrected format string is:

```python
DATETIME_FORMAT = 'Y-m-d H:i:s'
```

This should resolve #638. 🙂

