### PR TITLE
add Broker Documentation

### DIFF
--- a/docs/api/tom_alerts/brokers.rst
+++ b/docs/api/tom_alerts/brokers.rst
@@ -22,6 +22,9 @@ ALeRCE
 ANTARES
 *******
 
+.. automodule:: tom_alerts.brokers.antares
+    :members:
+
 .. automodule:: tom_antares.antares
     :members:
 
@@ -35,6 +38,9 @@ Lasair
 ******
 Hermes
 ******
+
+.. automodule:: tom_alerts.brokers.hermes
+    :members:
 
 .. automodule:: tom_hermes.hermes
     :members:

--- a/tom_alerts/brokers/antares.py
+++ b/tom_alerts/brokers/antares.py
@@ -19,6 +19,15 @@ class ANTARESQueryForm(GenericQueryForm):
 
 
 class ANTARESBroker(GenericBroker):
+    """
+    In order to install the Antares Broker plugin, please see
+    these instructions at https://github.com/TOMToolkit/tom_antares.
+
+    There is a known compatibility issue with antares-client required for the TOM_Antares Broker.
+    The antares-client requires the librdkafka library to be installed in order to be compatible with Python 3.10.
+    You can learn more about this on the
+    antares-client website (https://nsf-noirlab.gitlab.io/csdc/antares/client/installation.html) .
+    """
     name = 'ANTARES'
     form = ANTARESQueryForm
 

--- a/tom_alerts/brokers/hermes.py
+++ b/tom_alerts/brokers/hermes.py
@@ -19,6 +19,9 @@ class HermesQueryForm(GenericQueryForm):
 
 
 class HermesBroker(GenericBroker):
+    """
+    In order to install the full plugin, please see the instructions at https://github.com/TOMToolkit/tom_hermes.
+    """
     name = 'Hermes'
     form = HermesQueryForm
 


### PR DESCRIPTION
Just adds some basic Docstrings from Antares and Hermes Brokers.

These are a little misleading because they require the modules to be installed in Tom_base to generate the full docstrings.
This obviously isn't possible right now for TOM Antares, and isn't done right now for Tom_Hermes, so this just adds the stub version docstrings to the readthedocs that explain how to install the full version.