### PR TITLE
remove extra space from text areas in Firefox

### DIFF
--- a/tom_common/static/tom_common/css/main.css
+++ b/tom_common/static/tom_common/css/main.css
@@ -21,3 +21,9 @@ body {
 #login-buttons > li {
   margin: 0 2px 0 2px;
 }
+
+/* see https://github.com/twbs/bootstrap/issues/23295 */
+textarea {
+    overflow-y: auto;
+    overflow-x: hidden;
+}


### PR DESCRIPTION
There is a known issue that adds extra space to Bootstrap text areas in Firefox: https://github.com/twbs/bootstrap/issues/23295

This adds a workaround so that single-line text areas are the same height as char fields in all browsers. Example screenshots attached. Note the height of the first field.

![Screenshot 2023-12-14 at 14-11-33 SAGUARO Report to TNS](https://github.com/TOMToolkit/tom_base/assets/1976665/c016e08d-b4dd-4371-bb80-47d26ecdae6c)
![Screenshot 2023-12-14 at 14-36-11 SAGUARO Report to TNS](https://github.com/TOMToolkit/tom_base/assets/1976665/ed096f63-9101-44c4-91ad-ea8bb88e9dae)
