### PR TITLE
Add "Select All" checkbox and functionality to alert query view.

### DIFF
--- a/tom_alerts/templates/tom_alerts/query_result.html
+++ b/tom_alerts/templates/tom_alerts/query_result.html
@@ -12,7 +12,7 @@
   <table class="table table-striped">
     <thead>
       <tr>
-        <th></th>
+        <th><input type="checkbox" id="selectAll"/></th>
         <th>Time</th>
         <th>Name</th>
         <th>RA</th>
@@ -41,4 +41,26 @@
 {% if broker_feedback %}
   <div class="alert alert-danger" role="alert">{{broker_feedback |safe }}</div>
 {% endif %}
+
+<script>
+  document.getElementById("selectAll").addEventListener("change", function() {
+    // If the select all checkbox state changes, this will change the state
+    // of all checkboxes with the name attribute "alerts.
+    document.querySelectorAll(`input[name="alerts"]`).forEach(item => {
+      item.checked = this.checked;
+    });
+  });
+
+  document.querySelectorAll(`input[name="alerts"]`).forEach(item => {
+    item.addEventListener("change", function() {
+      let selectAllCheckbox = document.getElementById("selectAll");
+      // If all checkboxes with the name attribute "alerts" are checked, this
+      // will also check the "selectAll" checkbox.
+      const alertsCheckboxes = document.querySelectorAll(`input[name="alerts"]`);
+      const allChecked = Array.from(alertsCheckboxes).every(checkbox => checkbox.checked);
+      selectAllCheckbox.checked = allChecked;
+    });
+  });
+</script>
+
 {% endblock %}

--- a/tom_alerts/tests/tests.py
+++ b/tom_alerts/tests/tests.py
@@ -1,4 +1,5 @@
 import json
+from requests import HTTPError
 from unittest.mock import patch
 
 from django import forms
@@ -192,6 +193,22 @@ class TestBrokerViews(TestCase):
         )
         response = self.client.get(reverse('tom_alerts:run', kwargs={'pk': broker_query.id}))
         self.assertContains(response,  '66')
+
+    @patch('tom_alerts.tests.tests.TestBroker.fetch_alerts')
+    def test_handle_http_error(self, mock_fetch_alerts):
+        broker_query = BrokerQuery.objects.create(
+            name='find hoth',
+            broker='TEST',
+            parameters={'name': 'Hoth'},
+        )
+        # Set up the mock to raise an HTTPError
+        mock_fetch_alerts.side_effect = HTTPError("Test HTTP Error")
+
+        # Replace 'query_id' with the appropriate identifier for your test query
+        response = self.client.get(reverse('tom_alerts:run', kwargs={'pk': broker_query.id}))
+
+        # Assert that the HTTPError is handled as expected
+        self.assertContains(response, "Issue fetching alerts, please try again.")
 
     def test_update_query(self):
         broker_query = BrokerQuery.objects.create(

--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 import json
 import logging
+from requests import HTTPError
 from typing import List
 
 from django.views.generic.edit import DeleteView, FormMixin, FormView, ProcessFormView
@@ -247,6 +248,10 @@ class RunQueryView(TemplateView):
                                 Please see the <a href="{broker_help}" target="_blank">documentation</a> for more
                                 information.
                                 """
+        except HTTPError as e:
+            alerts = iter(())
+            broker_feedback = f"Issue fetching alerts, please try again.</br>{e}"
+
         # Post-query tasks
         query.last_run = timezone.now()
         query.save()


### PR DESCRIPTION
Hey TOM team! A few suggested changes:

**Select All Checkbox**: Implemented a checkbox for selecting all targets returned from an alert query. This enhancement provides a convenient way for users to quickly select all targets and create corresponding target entries. The state of the checkbox is dynamically updated based on user selections as well.

**HTTPError Handling**: Added user feedback for cases where the alert query results in a timeout (previously leading to a 404 error) or any HTTPError. Now, if a query takes too long to execute, the system informs the user about the timeout and proceeds without returning any alerts. 

Not implemented but what do you think about removing the separate "View" column in the query results table. Instead, we can combine the URL of the alert with the target name, such as `<td><a href="{{ alert.url }}" target="_blank" title="View alert">{{ alert.name }}</a></td>`. This change reduces the amount on the screen. 