### PR TITLE
Enhancement: Extend settings to set default plotly theme.

### DIFF
--- a/tom_common/apps.py
+++ b/tom_common/apps.py
@@ -1,5 +1,18 @@
 from django.apps import AppConfig
+from django.conf import settings
+import plotly.io as pio
 
 
 class TomCommonConfig(AppConfig):
     name = 'tom_common'
+
+    def ready(self):
+        # Set default plotly theme on startup
+        valid_themes = ['plotly', 'plotly_white', 'plotly_dark', 'ggplot2', 'seaborn', 'simple_white', 'none']
+
+        # Get the theme from settings, default to "plotly_white".
+        plotly_theme = getattr(settings, 'PLOTLY_THEME', 'plotly_white')
+        if plotly_theme not in valid_themes:
+            plotly_theme = 'plotly_white'
+
+        pio.templates.default = plotly_theme

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -322,6 +322,10 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 100
 }
 
+# Default Plotly theme setting, can set to any valid theme:
+# 'plotly', 'plotly_white', 'plotly_dark', 'ggplot2', 'seaborn', 'simple_white', 'none'
+PLOTLY_THEME = 'plotly_white'
+
 try:
     from local_settings import * # noqa
 except ImportError:


### PR DESCRIPTION
This PR introduces the ability for users to customize the `plotly` theme directly from `settings.py`. By default, the theme is set to `plotly_white`, maintaining the current default behavior. 

This change empowers users with more flexibility in customizing the appearance of their Plotly charts, aligning with their personal or organizational branding and styling preferences. In the future, this should be extended to allow users to provide their own templates. 