### PR TITLE
Modify comment deletion view to use form_valid.

### DIFF
--- a/tom_common/views.py
+++ b/tom_common/views.py
@@ -176,13 +176,14 @@ class CommentDeleteView(LoginRequiredMixin, DeleteView):
     """
     model = Comment
 
-    def delete(self, request, *args, **kwargs):
+    def form_valid(self, form):
         """
-        Method that handles the DELETE request for a ``Comment``. Validates that the user either authored the comment or
-        is a superuser, then deletes the ``Comment``.
+        Checks if the user is authorized to delete the comment and then proceeds with deletion.
         """
-        if request.user == self.get_object().user or request.user.is_superuser:
-            self.success_url = self.get_object().get_absolute_url()
-            return super().delete(request, *args, **kwargs)
-        else:
-            return HttpResponseForbidden('Not authorized')
+        self.object = self.get_object()
+
+        if self.request.user == self.object.user or self.request.user.is_superuser:
+            self.success_url = self.object.content_object.get_absolute_url()
+            return super().form_valid(form)
+
+        return HttpResponseForbidden('Not authorized')


### PR DESCRIPTION
Hi TOMTeam,

This PR introduces key updates to the `CommentDeleteView` in TOMToolkit.

- **CommentDeleteView Update**: Modified the view to use `form_valid` instead of `delete` for handling DELETE requests, aligning with Django's updated practices. 
- **Bugfix**: Corrects where the user is redirected to on success, addressing #649 
- **Testing Enhancements**: Added a new test class `CommentDeleteViewTest` in `tom_common/tests.py`, covering various scenarios including redirection for not logged-in users, authorization checks for superusers and normal users, and ensuring proper deletion.