### PR TITLE
User Permissions for new targets & CSV fixes

### DIFF
--- a/tom_alerts/tests/tests.py
+++ b/tom_alerts/tests/tests.py
@@ -8,6 +8,7 @@ from django.contrib.messages import get_messages
 from django.core.cache import cache
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from guardian.shortcuts import get_perms
 
 from tom_alerts.alerts import GenericBroker, GenericQueryForm, GenericUpstreamSubmissionForm, GenericAlert
 from tom_alerts.alerts import get_service_class, get_service_classes
@@ -246,6 +247,8 @@ class TestBrokerViews(TestCase):
         self.assertEqual(Target.objects.count(), 1)
         self.assertEqual(Target.objects.first().name, 'Hoth')
         self.assertRedirects(response, reverse('tom_targets:list'))
+        # Check Group level permissions
+        self.assertIn("view_target", get_perms(self.user, Target.objects.first()))
 
     @override_settings(CACHES={
             'default': {

--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -308,6 +308,8 @@ class CreateTargetFromAlertView(LoginRequiredMixin, View):
             target, extras, aliases = generic_alert.to_target()
             try:
                 target.save(extras=extras, names=aliases)
+                # Give the user access to the target they created
+                target.give_user_access(self.request.user)
                 broker_class().process_reduced_data(target, json.loads(cached_alert))
                 for group in request.user.groups.all().exclude(name='Public'):
                     assign_perm('tom_targets.view_target', group, target)

--- a/tom_targets/models.py
+++ b/tom_targets/models.py
@@ -8,6 +8,7 @@ from django.db import models, transaction
 from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils.module_loading import import_string
+from guardian.shortcuts import assign_perm
 
 from tom_common.hooks import run_hook
 
@@ -407,6 +408,16 @@ class Target(models.Model):
             fields_for_type = GLOBAL_TARGET_FIELDS
 
         return model_to_dict(self, fields=fields_for_type)
+
+    def give_user_access(self, user):
+        """
+        Gives the given user permissions to view this target.
+        :param user:
+        :return:
+        """
+        assign_perm('targets.view_target', user, self)
+        assign_perm('targets.change_target', user, self)
+        assign_perm('targets.delete_target', user, self)
 
 
 class TargetName(models.Model):

--- a/tom_targets/static/tom_targets/target_import.csv
+++ b/tom_targets/static/tom_targets/target_import.csv
@@ -1,3 +1,3 @@
-name,name2,type,ra,dec
-m13,Hercules Globular Cluster,SIDEREAL,250.421,36.459
-m27,Dumbbell Nebula,SIDEREAL,299.901,22.721
+name,name2,type,ra,dec,groups
+m13,Hercules Globular Cluster,SIDEREAL,250.421,36.459,"Public, Private"
+m27,Dumbbell Nebula,SIDEREAL,299.901,22.721,"Public, Private"

--- a/tom_targets/templates/tom_targets/target_import.html
+++ b/tom_targets/templates/tom_targets/target_import.html
@@ -4,9 +4,18 @@
 {% block content %}
 <h3>Import Targets</h3>
 <p>
-  Upload a .csv to import targets in bulk. CSV columns must match target attributes.
-  View the <a href="{% static 'tom_targets/target_import.csv' %}">example .csv file</a>.
+  Upload a .csv to import targets in bulk. CSV columns must match
+  <a href="https://tom-toolkit.readthedocs.io/en/stable/api/tom_targets/models.html">target attributes</a>.
+  Additional colimns will be checked against your
+  <a href="https://tom-toolkit.readthedocs.io/en/stable/targets/target_fields.html">EXTRA_FIELDS</a> and added if relevant.
+  <hr>
+  You can include a list of groups in a "groups" column to add targets to permission groups.
+  These are different from the target groups or target lists and will be used for determining which users can view the target.
+  If the group does not exist, it will be skipped.
+  <hr>
+  See <a href="{% static 'tom_targets/target_import.csv' %}">target_import.csv</a> for an example.
 </p>
+<hr>
 <form method="POST" action="{% url 'tom_targets:import' %}" enctype="multipart/form-data">
   {% csrf_token %}
   <input type="file" name="target_csv">

--- a/tom_targets/templates/tom_targets/target_import.html
+++ b/tom_targets/templates/tom_targets/target_import.html
@@ -10,7 +10,7 @@
   <a href="https://tom-toolkit.readthedocs.io/en/stable/targets/target_fields.html">EXTRA_FIELDS</a> and added if relevant.
   <hr>
   You can include a list of groups in an optional "groups" column to add targets to permission groups.
-  These are different from target lists and will be used for determining which users can view the target.
+  These permission groups are different from target lists and will be used for determining which users can view the target.
   If the group does not exist, it will be ignored.
   <hr>
   See <a href="{% static 'tom_targets/target_import.csv' %}">target_import.csv</a> for an example.

--- a/tom_targets/templates/tom_targets/target_import.html
+++ b/tom_targets/templates/tom_targets/target_import.html
@@ -10,8 +10,8 @@
   <a href="https://tom-toolkit.readthedocs.io/en/stable/targets/target_fields.html">EXTRA_FIELDS</a> and added if relevant.
   <hr>
   You can include a list of groups in a "groups" column to add targets to permission groups.
-  These are different from the target groups or target lists and will be used for determining which users can view the target.
-  If the group does not exist, it will be skipped.
+  These are different from target lists and will be used for determining which users can view the target.
+  If the group does not exist, it will be ignored.
   <hr>
   See <a href="{% static 'tom_targets/target_import.csv' %}">target_import.csv</a> for an example.
 </p>

--- a/tom_targets/templates/tom_targets/target_import.html
+++ b/tom_targets/templates/tom_targets/target_import.html
@@ -9,7 +9,7 @@
   Additional colimns will be checked against your
   <a href="https://tom-toolkit.readthedocs.io/en/stable/targets/target_fields.html">EXTRA_FIELDS</a> and added if relevant.
   <hr>
-  You can include a list of groups in a "groups" column to add targets to permission groups.
+  You can include a list of groups in an optional "groups" column to add targets to permission groups.
   These are different from target lists and will be used for determining which users can view the target.
   If the group does not exist, it will be ignored.
   <hr>

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -874,7 +874,7 @@ class TestTargetImport(TestCase):
         csv_content = b"name,type,ra,dec\nm13,SIDEREAL,250.421,36.459\nm27,SIDEREAL,299.901,22.721"
         csv_file = SimpleUploadedFile("test.csv", csv_content, content_type="text/csv")
 
-        response = self.client.post(reverse('targets:import'), {'target_csv': csv_file})
+        self.client.post(reverse('targets:import'), {'target_csv': csv_file})
 
         csv_file.close()
         targets = Target.objects.all()
@@ -882,7 +882,6 @@ class TestTargetImport(TestCase):
             self.assertIn("view_target", get_perms(self.user, target))
 
     def test_import_csv(self):
-        from guardian.shortcuts import get_perms
         csv = [
             'name,type,ra,dec',
             'm13,SIDEREAL,250.421,36.459',

--- a/tom_targets/utils.py
+++ b/tom_targets/utils.py
@@ -53,18 +53,18 @@ def export_targets(qs):
     return file_buffer
 
 
-def import_targets(targets):
+def import_targets(target_stream):
     """
     Imports a set of targets into the TOM and saves them to the database.
 
-    :param targets: String buffer of targets
-    :type targets: StringIO
+    :param target_stream: String buffer of targets
+    :type target_stream: StringIO
 
     :returns: dictionary of successfully imported targets, as well errors
     :rtype: dict
     """
     # TODO: Replace this with an in memory iterator
-    targetreader = csv.DictReader(targets, dialect=csv.excel)
+    targetreader = csv.DictReader(target_stream, dialect=csv.excel)
     targets = []
     errors = []
     base_target_fields = [field.name for field in Target._meta.get_fields()]

--- a/tom_targets/utils.py
+++ b/tom_targets/utils.py
@@ -1,5 +1,4 @@
 from django.db.models import Count
-from guardian.shortcuts import assign_perm
 from django.contrib.auth.models import Group
 
 import csv
@@ -103,9 +102,7 @@ def import_targets(target_stream):
             for group in group_names:
                 try:
                     group_instance = Group.objects.get(name=group)
-                    assign_perm('tom_targets.view_target', group_instance, target)
-                    assign_perm('tom_targets.change_target', group_instance, target)
-                    assign_perm('tom_targets.delete_target', group_instance, target)
+                    target.give_user_access(group_instance)
                 except Group.DoesNotExist:
                     pass
         except Exception as e:

--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -467,6 +467,8 @@ class TargetImportView(LoginRequiredMixin, TemplateView):
         csv_file = request.FILES['target_csv']
         csv_stream = StringIO(csv_file.read().decode('utf-8'), newline=None)
         result = import_targets(csv_stream)
+        for target in result['targets']:
+            target.give_user_access(request.user)
         messages.success(
             request,
             'Targets created: {}'.format(len(result['targets']))

--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -205,6 +205,9 @@ class TargetCreateView(LoginRequiredMixin, CreateView):
             form.add_error(None, names.errors)
             form.add_error(None, names.non_form_errors())
             return super().form_invalid(form)
+        # Give the user access to the target they created
+        self.object.give_user_access(self.request.user)
+        # Run the target post save hook
         logger.info('Target post save hook: %s created: %s', self.object, True)
         run_hook('target_post_save', target=self.object, created=True)
         return redirect(self.get_success_url())


### PR DESCRIPTION
This PR is to allow users to be able to view, edit, and delete targets that they create.
It adds permissions by default to the current user for the new target.

It also updates the csv file example and import process to handle USER GROUP permissions for the ingested target.