### PR TITLE
add ztf as telescope

### DIFF
--- a/tom_alerts/brokers/alerce.py
+++ b/tom_alerts/brokers/alerce.py
@@ -359,6 +359,7 @@ class ALeRCEBroker(GenericBroker):
                 'filter': FILTERS[detection['fid']],
                 'magnitude': detection['diffmaglim'],
                 'error': detection['sigmapsf'],
+                'telescope': 'ZTF',
             }
             ReducedDatum.objects.get_or_create(
                 timestamp=mjd.to_datetime(TimezoneInfo()),
@@ -374,6 +375,7 @@ class ALeRCEBroker(GenericBroker):
             value = {
                 'filter': FILTERS[non_detection['fid']],
                 'limit': non_detection['diffmaglim'],
+                'telescope': 'ZTF',
             }
             ReducedDatum.objects.get_or_create(
                 timestamp=mjd.to_datetime(TimezoneInfo()),


### PR DESCRIPTION
This is a pretty simple change to add "ZTF" as the Telescope to the value of the `reduced_datum` when LC data is found during the ALeRCE Broker query.

This is necessary to share Data with Hermes.