### PR TITLE
quotes around button title text

### DIFF
--- a/tom_targets/templates/tom_targets/partials/module_buttons.html
+++ b/tom_targets/templates/tom_targets/partials/module_buttons.html
@@ -1,3 +1,3 @@
 {% for button in button_list %}
-    <a href="{% url button.namespace pk=target.id %}" title={{button.title}} class="{{ button.class }}">{{button.text}}</a>
+    <a href="{% url button.namespace pk=target.id %}" title="{{button.title}}" class="{{ button.class }}">{{button.text}}</a>
 {% endfor %}


### PR DESCRIPTION
This is a minor fix to allow mouseover (title) text for custom buttons.