### PR TITLE
rename magnitude_error to error

### DIFF
--- a/tom_dataproducts/alertstreams/hermes.py
+++ b/tom_dataproducts/alertstreams/hermes.py
@@ -162,8 +162,8 @@ def create_hermes_phot_table_row(datum, **kwargs):
         phot_table_row['brightness'] = datum.value['magnitude']
     else:
         phot_table_row['limiting_brightness'] = datum.value.get('limit', None)
-    if datum.value.get('magnitude_error', None):
-        phot_table_row['brightness_error'] = datum.value['magnitude_error']
+    if datum.value.get('error', None):
+        phot_table_row['brightness_error'] = datum.value['error']
     return phot_table_row
 
 
@@ -243,7 +243,7 @@ def get_hermes_phot_value(phot_data):
     :return: Dictionary containing properly formatted parameters for Reduced_Datum
     """
     data_dictionary = {
-        'magnitude_error': phot_data.get('brightness_error', ''),
+        'error': phot_data.get('brightness_error', ''),
         'filter': phot_data['bandpass'],
         'telescope': phot_data.get('telescope', ''),
         'instrument': phot_data.get('instrument', ''),

--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -351,7 +351,7 @@ class ReducedDatum(models.Model):
 
                     {
                       'magnitude': 18.5,
-                      'magnitude_error': .5,
+                      'error': .5,
                       'filter': 'r',
                       'telescope': 'ELP.domeA.1m0a',
                       'instrument': 'fa07',

--- a/tom_dataproducts/processors/panstarrs_processor.py
+++ b/tom_dataproducts/processors/panstarrs_processor.py
@@ -82,7 +82,7 @@ class PanstarrsProcessor(DataProcessor):
                             'timestamp': timestamp,
                             'telescope': 'PanSTARRS 1',
                             'magnitude': mag,
-                            'magnitude_error': mag_err,
+                            'error': mag_err,
                             'filter': optical_filter,
                         }
                         photometry.append(value)

--- a/tom_dataproducts/templates/tom_dataproducts/partials/photometry_datalist_for_target.html
+++ b/tom_dataproducts/templates/tom_dataproducts/partials/photometry_datalist_for_target.html
@@ -36,7 +36,7 @@
                     {% if datum.limit %}>{% endif %}
                     {{ datum.magnitude|truncate_number }}
                 </td>
-                <td>{{ datum.magnitude_error|floatformat:4 }}</td>
+                <td>{{ datum.error|floatformat:4 }}</td>
                 <td>{{ datum.source }}</td>
             </tr>
             {% empty %}

--- a/tom_dataproducts/templatetags/dataproduct_extras.py
+++ b/tom_dataproducts/templatetags/dataproduct_extras.py
@@ -176,7 +176,7 @@ def get_photometry_data(context, target, target_share=False):
                    'source': reduced_datum.source_name,
                    'filter': reduced_datum.value.get('filter', ''),
                    'telescope': reduced_datum.value.get('telescope', ''),
-                   'magnitude_error': reduced_datum.value.get('magnitude_error', '')
+                   'error': reduced_datum.value.get('error', '')
                    }
 
         if 'limit' in reduced_datum.value.keys():

--- a/tom_dataproducts/tests/test_sharing.py
+++ b/tom_dataproducts/tests/test_sharing.py
@@ -19,17 +19,17 @@ class TestHermesSharing(TestCase):
         self.rd1 = ReducedDatum.objects.create(
             target=self.target,
             data_type='photometry',
-            value={'magnitude': 18.5, 'magnitude_error': .5, 'filter': 'V', 'telescope': 'tst'}
+            value={'magnitude': 18.5, 'error': .5, 'filter': 'V', 'telescope': 'tst'}
         )
         self.rd2 = ReducedDatum.objects.create(
             target=self.target,
             data_type='photometry',
-            value={'magnitude': 19.5, 'magnitude_error': .5, 'filter': 'B', 'telescope': 'tst'}
+            value={'magnitude': 19.5, 'error': .5, 'filter': 'B', 'telescope': 'tst'}
         )
         self.rd3 = ReducedDatum.objects.create(
             target=self.target,
             data_type='photometry',
-            value={'magnitude': 17.5, 'magnitude_error': .5, 'filter': 'R', 'telescope': 'tst'}
+            value={'magnitude': 17.5, 'error': .5, 'filter': 'R', 'telescope': 'tst'}
         )
         self.message_info = BuildHermesMessage(
             title='Test Title',
@@ -64,7 +64,7 @@ class TestHermesSharing(TestCase):
                 self.assertEqual(hermes_datum['date_obs'], datum.timestamp.isoformat())
                 self.assertEqual(hermes_datum['telescope'], datum.value.get('telescope'))
                 self.assertEqual(hermes_datum['brightness'], datum.value.get('magnitude'))
-                self.assertEqual(hermes_datum['brightness_error'], datum.value.get('magnitude_error'))
+                self.assertEqual(hermes_datum['brightness_error'], datum.value.get('error'))
                 self.assertEqual(hermes_datum['bandpass'], datum.value.get('filter'))
 
     def test_convert_to_hermes_format(self):

--- a/tom_dataproducts/tests/tests.py
+++ b/tom_dataproducts/tests/tests.py
@@ -536,7 +536,7 @@ class TestReducedDatumModel(TestCase):
         self.timestamp = datetime.datetime.now()
         self.existing_reduced_datum_value = {
             'magnitude': 18.5,
-            'magnitude_error': .5,
+            'error': .5,
             'filter': 'r',
             'telescope': 'ELP.domeA.1m0a',
             'instrument': 'fa07'}
@@ -551,7 +551,7 @@ class TestReducedDatumModel(TestCase):
         """Test that we can add a second unique ReducedDatum"""
         second_reduced_datum_value = {
             'magnitude': 10.5,
-            'magnitude_error': 1.5,
+            'error': 1.5,
             'filter': 'g',
             'telescope': 'ELP.domeA.1m0a',
             'instrument': 'fa07'}


### PR DESCRIPTION
This resolves #790 by making the naming convention for uncertainties on magnitudes consistent as "error". This should be resolved more robustly according to #609, but in the mean time, this allows the photometry table on the target detail page to work.