### PR TITLE
add magnitude_error compatability

### DIFF
--- a/tom_dataproducts/alertstreams/hermes.py
+++ b/tom_dataproducts/alertstreams/hermes.py
@@ -162,8 +162,9 @@ def create_hermes_phot_table_row(datum, **kwargs):
         phot_table_row['brightness'] = datum.value['magnitude']
     else:
         phot_table_row['limiting_brightness'] = datum.value.get('limit', None)
-    if datum.value.get('error', None):
-        phot_table_row['brightness_error'] = datum.value['error']
+    error_value = datum.value.get('error', datum.value.get('magnitude_error', None))
+    if error_value is not None:
+        phot_table_row['brightness_error'] = error_value
     return phot_table_row
 
 

--- a/tom_dataproducts/templates/tom_dataproducts/partials/photometry_datalist_for_target.html
+++ b/tom_dataproducts/templates/tom_dataproducts/partials/photometry_datalist_for_target.html
@@ -36,7 +36,11 @@
                     {% if datum.limit %}>{% endif %}
                     {{ datum.magnitude|truncate_number }}
                 </td>
-                <td>{{ datum.error|floatformat:4 }}</td>
+                {% if datum.error %}
+                    <td>{{ datum.error|floatformat:4 }}</td>
+                {% else %}
+                    <td>{{ datum.magnitude_error|floatformat:4 }}</td>
+                {% endif %}
                 <td>{{ datum.source }}</td>
             </tr>
             {% empty %}

--- a/tom_dataproducts/templatetags/dataproduct_extras.py
+++ b/tom_dataproducts/templatetags/dataproduct_extras.py
@@ -176,7 +176,7 @@ def get_photometry_data(context, target, target_share=False):
                    'source': reduced_datum.source_name,
                    'filter': reduced_datum.value.get('filter', ''),
                    'telescope': reduced_datum.value.get('telescope', ''),
-                   'error': reduced_datum.value.get('error', '')
+                   'error': reduced_datum.value.get('error', reduced_datum.value.get('magnitude_error', ''))
                    }
 
         if 'limit' in reduced_datum.value.keys():


### PR DESCRIPTION
This adds some backwards compatibility for functions that previously relied on `magnitude_error` that have been now changed to use `error` instead.