### PR TITLE
 add option to override defaults to converttargetextras

### DIFF
--- a/docs/targets/target_fields.rst
+++ b/docs/targets/target_fields.rst
@@ -228,7 +228,8 @@ more the of the ``Extra Field`` and ``Target Field`` names respectively.
     ./manage.py converttargetextras --target_extra extra_bool extra_number --model_field example_bool example_number
 
 This command will go through each target and transfer the data from the ``Extra Field`` to the ``Target Field``. If the
-``Target Field`` is already populated, the data will not be transferred. When finished, the ``Extra Field`` data will be
+``Target Field`` is already populated with a value other than the default value, the data will not be transferred unless
+the ``--force`` flag is set. When finished, the ``Extra Field`` data will be
 deleted, and you will likely want to remove the ``EXTRA_FIELDS`` setting from your ``settings.py`` file.
 
 Adding ``Extra Fields``

--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -322,6 +322,6 @@ REST_FRAMEWORK = {
 }
 
 try:
-    from .local_settings import *  # noqa
+    from local_settings import *  # noqa
 except ImportError:
     pass

--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -322,6 +322,6 @@ REST_FRAMEWORK = {
 }
 
 try:
-    from local_settings import *  # noqa
+    from .local_settings import *  # noqa
 except ImportError:
     pass

--- a/tom_targets/management/commands/converttargetextras.py
+++ b/tom_targets/management/commands/converttargetextras.py
@@ -115,8 +115,9 @@ class Command(BaseCommand):
             target = Target.objects.get(pk=extra.target.pk)
             model_field_default = Target._meta.get_field(chosen_model_field).get_default()
             # If model already has a value, don't overwrite unless it's the default value or force is True
-            if not force and getattr(target, chosen_model_field, None) \
-                    and getattr(target, chosen_model_field) != model_field_default:
+            if not force and \
+                    getattr(target, chosen_model_field, None) and \
+                    getattr(target, chosen_model_field) != model_field_default:
                 self.stdout.write(f"{self.style.ERROR('Warning:')} {target}.{chosen_model_field} "
                                   f"already has a value: {getattr(target, chosen_model_field)}. Skipping.")
                 continue


### PR DESCRIPTION
This code will automatically overwrite default values with ones from TargetExtras, but will also allow a user to overwrite any value using the `--force`` flag.