### PR TITLE
exclude identical object in ReducedDatum.validate_unique

### DIFF
--- a/tom_dataproducts/models.py
+++ b/tom_dataproducts/models.py
@@ -408,7 +408,7 @@ class ReducedDatum(models.Model):
                                                               data_type=self.data_type,
                                                               timestamp=self.timestamp,
                                                               value=self.value)
-            if existing_reduced_datum:
+            if existing_reduced_datum and existing_reduced_datum.id != self.id:  # not the same object
                 # found ReducedDatum with the same values. Don't save this duplicate ReducedDatum.
                 raise ValidationError(f'ReducedDatum already exists: {self.data_type} data with value of {self.value} '
                                       f'found for {self.target} at {self.timestamp}')


### PR DESCRIPTION
Right now, it's not possible to update an existing `ReducedDatum`, because its `validate_unique` method will always find *itself* as a duplicate.