### PR TITLE
do not export pointer keys for csv files

### DIFF
--- a/tom_targets/utils.py
+++ b/tom_targets/utils.py
@@ -49,7 +49,10 @@ def export_targets(qs):
         for name in names:
             target_data[f'name{str(name_index)}'] = name.name
             name_index += 1
-        del target_data['id']  # do not export 'id'
+        # do not export 'pk's
+        for pointer_key in [pk for pk in target_data.keys() if pk.endswith('_ptr_id')]:
+            del target_data[pointer_key]
+        del target_data['id']
         writer.writerow(target_data)
     return file_buffer
 


### PR DESCRIPTION
The extended target model will create a pointer key to the parent model (`basetarget_ptr_id`) that we don't want passed.
This will keep those form trying to be written in the csv and breaking that process.