### PR TITLE
Updated name of config for single target data services

### DIFF
--- a/docs/managing_data/single_target_data_service.rst
+++ b/docs/managing_data/single_target_data_service.rst
@@ -88,7 +88,7 @@ a redis server, you would add the following to your ``settings.py``:
 After adding the ``django_dramatiq`` installed app, you will need to run ``./manage.py migrate`` once to setup
 its DB tables. If this configuration is set in your TOM, the existing services which support asynchronous queries,
 Atlas and ZTF, should start querying asynchronously. (Note: You must also start the dramatiq workers:
-``./manage.py rundramatic``. If you do not add these settings, those services will still function but will fall
+``./manage.py rundramatiq``. If you do not add these settings, those services will still function but will fall
 back to synchronous queries.
 
 

--- a/tom_dataproducts/single_target_data_service/panstarrs_service/panstarrs.py
+++ b/tom_dataproducts/single_target_data_service/panstarrs_service/panstarrs.py
@@ -136,17 +136,17 @@ class PanstarrsSingleTargetDataService(stds.BaseSingleTargetDataService):
             raise stds.SingleTargetDataServiceException(f"Target {query_parameters.get('target_id')} does not exist")
 
         # make sure PANSTARRS service is configured
-        if 'PANSTARRS' not in settings.FORCED_PHOTOMETRY_SERVICES:
+        if 'PANSTARRS' not in settings.SINGLE_TARGET_DATA_SERVICES:
             raise stds.SingleTargetDataServiceException(
-                "Must specify 'PANSTARRS' configuration in settings.py FORCED_PHOTOMETRY_SERVICES"
+                "Must specify 'PANSTARRS' configuration in settings.py SINGLE_TARGET_DATA_SERVICES"
             )
-        if not settings.FORCED_PHOTOMETRY_SERVICES.get('PANSTARRS', {}).get('url'):
+        if not settings.SINGLE_TARGET_DATA_SERVICES.get('PANSTARRS', {}).get('url'):
             raise stds.SingleTargetDataServiceException(
-                "Must specify a 'url' under PANSTARRS settings in FORCED_PHOTOMETRY_SERVICES"
+                "Must specify a 'url' under PANSTARRS settings in SINGLE_TARGET_DATA_SERVICES"
             )
         # it's not clear if this is stricly necessary, so just warn for now
-        if not settings.FORCED_PHOTOMETRY_SERVICES.get('PANSTARRS', {}).get('api_key'):
-            logger.warning('PanSTARRS api_key not specified in setings.py FORCED_PHOTOMETRY_SERVICES: '
+        if not settings.SINGLE_TARGET_DATA_SERVICES.get('PANSTARRS', {}).get('api_key'):
+            logger.warning('PanSTARRS api_key not specified in setings.py SINGLE_TARGET_DATA_SERVICES: '
                            'Only public data will be accessible.')
 
         # submit the query, create the data product, and run the data product processor

--- a/tom_dataproducts/single_target_data_service/panstarrs_service/panstarrs_api.py
+++ b/tom_dataproducts/single_target_data_service/panstarrs_service/panstarrs_api.py
@@ -13,8 +13,8 @@ def get_base_url():
     """return the PanSTARRS MAST API base URL from settings
     """
     # the configuration in settings.py has all been vetted in
-    # panstarrs.PanstarrsForcedPhotometryService.query_service()
-    base_url = settings.FORCED_PHOTOMETRY_SERVICES.get('PANSTARRS', {}).get('url')
+    # panstarrs.PanstarrsSingleTargetDataServiceQueryForm.query_service()
+    base_url = settings.SINGLE_TARGET_DATA_SERVICES.get('PANSTARRS', {}).get('url')
 
     return base_url
 

--- a/tom_dataproducts/tasks.py
+++ b/tom_dataproducts/tasks.py
@@ -24,9 +24,9 @@ logger.setLevel(logging.DEBUG)
 def atlas_query(min_date_mjd, max_date_mjd, target_id, data_product_type):
     logger.debug('Calling atlas query!')
     target = Target.objects.get(pk=target_id)
-    headers = {"Authorization": f"Token {settings.FORCED_PHOTOMETRY_SERVICES.get('ATLAS', {}).get('api_key')}",
+    headers = {"Authorization": f"Token {settings.SINGLE_TARGET_DATA_SERVICES.get('ATLAS', {}).get('api_key')}",
                "Accept": "application/json"}
-    base_url = settings.FORCED_PHOTOMETRY_SERVICES.get('ATLAS', {}).get('url')
+    base_url = settings.SINGLE_TARGET_DATA_SERVICES.get('ATLAS', {}).get('url')
     task_url = None
     while not task_url:
         with requests.Session() as s:


### PR DESCRIPTION
If you follow the documentation for [integrating a single target data service](https://tom-toolkit.readthedocs.io/en/stable/managing_data/single_target_data_service.html) with a TOM, the name of the corresponding configuration dictionary in settings.py seems to have been changed.  This PR makes the code consistent with the docs, which use the more generalized data services terminology.  