### PR TITLE
add cancel button on observation record detail page.

### DIFF
--- a/tom_observations/templates/tom_observations/observationrecord_detail.html
+++ b/tom_observations/templates/tom_observations/observationrecord_detail.html
@@ -18,7 +18,12 @@
       {% endif %}
       <p class="my-auto"><strong>Observation ID:</strong> {{ object.observation_id }}</p>
       <p class="my-auto"><strong>Created:</strong> {{ object.created }} <strong>Modified:</strong> {{ object.modified }}</p>
-      <p class="my-auto"><strong>Status:</strong> {{ object.status }}</p>
+      <p class="my-auto">
+        <strong>Status:</strong> {{ object.status }}
+        {% if object.status == 'PENDING' %}
+          <a class="btn btn-danger" href="{% url 'tom_observations:cancel' pk=object.pk %}">Cancel Observation</a>
+        {% endif %}
+      </p>
     </div>
     <p></p>
     {% upload_dataproduct object %}


### PR DESCRIPTION
`cancel_observation` is already a valid facility method that has been established for LCO.

This PR just adds a cancel button to the observation record detail page if the status is pending.