### PR TITLE
update docs with a brief description of AnonymousUser

### DIFF
--- a/docs/common/customsettings.rst
+++ b/docs/common/customsettings.rst
@@ -86,6 +86,8 @@ documentation on `Adding Custom Fields to
 Targets </targets/target_fields>`__ for an explanation of how to use
 this feature.
 
+.. _custom_facility_settings:
+
 `FACILITIES <#facilities>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/common/permissions.rst
+++ b/docs/common/permissions.rst
@@ -14,7 +14,7 @@ The TOM Toolkit provides a permissions system that can be used in two different 
 ---------------
 
 When you first establish your TOM, ``django-guardian`` will create an ``AnonymousUser`` as the default user for the
-TOM. ``AnonymousUser`` is a special user that is used to represent users who are not logged in and only have permission
+TOM. ``AnonymousUser`` is a special user that is used to represent users who are not logged in and only has permission
 to see targets that are associated with the ``public`` group by default. This user is important for establishing what
 permissions are available to users who are not logged in and should not be removed. You can modify the permissions of
 ``AnonymousUser`` by using the Django admin interface or the methods described below.

--- a/docs/common/permissions.rst
+++ b/docs/common/permissions.rst
@@ -2,7 +2,7 @@ The Permissions System
 ======================
 
 The permissions system is built on top of
-`django-guardian <https://django-guardian.readthedocs.io/en/stable/>`_. It has been
+`django-guardian <https://django-guardian.readthedocs.io/en/stable/>`__. It has been
 kept as simple as possible, but TOM developers may extend the capabilities if
 needed.
 
@@ -18,6 +18,9 @@ TOM. ``AnonymousUser`` is a special user that is used to represent users who are
 to see targets that are associated with the ``public`` group by default. This user is important for establishing what
 permissions are available to users who are not logged in and should not be removed. You can modify the permissions of
 ``AnonymousUser`` by using the Django admin interface or the methods described below.
+
+*Note:* This ``AnonymousUser`` is not the same as the ``AnonymousUser`` object that is part of
+`Django's authentication system. <https://docs.djangoproject.com/en/5.1/ref/contrib/auth/#anonymoususer-object>`__
 
 
 

--- a/docs/common/permissions.rst
+++ b/docs/common/permissions.rst
@@ -10,6 +10,17 @@ The TOM Toolkit provides a permissions system that can be used in two different 
 ``TARGET_PERMISSIONS_ONLY`` boolean in ``settings.py``.
 
 
+`AnonymousUser`
+---------------
+
+When you first establish your TOM, ``django-guardian`` will create an ``AnonymousUser`` as the default user for the
+TOM. ``AnonymousUser`` is a special user that is used to represent users who are not logged in and only have permission
+to see targets that are associated with the ``public`` group by default. This user is important for establishing what
+permissions are available to users who are not logged in and should not be removed. You can modify the permissions of
+``AnonymousUser`` by using the Django admin interface or the methods described below.
+
+
+
 First Mode -- Permissions on Targets and Observation Records
 ------------------------------------------------------------
 
@@ -25,17 +36,12 @@ button found at the top of the groups table:
 
 .. image:: /_static/permissions_doc/addgroup.png
 
-![](/_static/permissions_doc/addgroup.png)
-
 Modifying a group will allow you to change it's name and add/remove users.
 
 When a user adds or modifies a target, they are able to choose the groups to
 assign to the target:
 
 .. image:: /_static/permissions_doc/targetgroups.png
-
-![](/_static/permissions_doc/targetgroups.png)
-
 
 By default the target will be assigned to all groups the user belongs to.
 

--- a/docs/introduction/faqs.rst
+++ b/docs/introduction/faqs.rst
@@ -40,8 +40,8 @@ I try to observe a target with LCO but get an error.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You might not have added your LCO api key to your settings file under
-the ``FACILITIES`` settings. See :doc:`Custom
-Settings </common/customsettings#facilities>` for more
+the ``FACILITIES`` settings. See :ref:`Custom
+Settings <custom_facility_settings>` for more
 details.
 
 How do I create a super user (PI)?
@@ -109,6 +109,9 @@ unauthenticated user. The user has no first name, last name, or
 password, and allows unauthenticated users to view unprotected pages
 within your TOM. Do not delete this user, as then an unauthorized user will not
 have access to the login page.
+
+*Note:* This ``AnonymousUser`` is not the same as the ``AnonymousUser`` object that is part of
+`Django's authentication system. <https://docs.djangoproject.com/en/5.1/ref/contrib/auth/#anonymoususer-object>`_
 
 How can I display an error message when authentication to an external facility fails?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/introduction/faqs.rst
+++ b/docs/introduction/faqs.rst
@@ -103,12 +103,12 @@ This will make the contents of ``newpage.html`` available under the path
 Who is AnonymousUser?
 ~~~~~~~~~~~~~~~~~~~~~
 
-AnonymousUser is a special profile that django-guardian, our permissions
+`AnonymousUser` is a special profile that django-guardian, our permissions
 library, creates automatically. AnonymousUser represents an
 unauthenticated user. The user has no first name, last name, or
 password, and allows unauthenticated users to view unprotected pages
-within your TOM. You can choose to delete the user if you don’t want any
-pages to be visible without logging in.
+within your TOM. Do not delete this user, as then an unauthorized user will not
+have access to the login page.
 
 How can I display an error message when authentication to an external facility fails?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is just meant to acknowledge the `AnonymousUser` and explain its purpose in the permissions section of the docs.
Let me know if you think this is sufficient and in the best location.
![image](https://github.com/user-attachments/assets/5779df86-617f-47bf-95ac-d8bfacdc018f)
