### PR TITLE
make broker settings consistent with docs

### DIFF
--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -273,7 +273,7 @@ BROKERS = {
         'bot_id': '',
         'bot_name': '',
     },
-    'Lasair': {
+    'LASAIR': {
         'api_key': '',
     }
 }


### PR DESCRIPTION
The Lasair API token needs to be capitalized.