### PR TITLE
display target model help text as tooltip

### DIFF
--- a/docs/targets/target_fields.rst
+++ b/docs/targets/target_fields.rst
@@ -101,8 +101,8 @@ The following is an example of a custom target model that adds a boolean field a
 
 
     class UserDefinedTarget(BaseTarget):
-        example_bool = models.BooleanField(default=False)
-        example_number = models.FloatField(null=True, blank=True)
+        example_bool = models.BooleanField(default=False, verbose_name='Example Boolean')
+        example_number = models.FloatField(null=True, blank=True, help_text='Pick a number.')
 
         # Set Hidden Fields
         example_bool.hidden = True
@@ -118,9 +118,10 @@ The following is an example of a custom target model that adds a boolean field a
 
 The model name, ``UserDefinedTarget`` in the example (line 6), can be replaced by whatever CamelCase name you want, but
 it must be a subclass of ``tom_targets.BaseTarget``. The ``null=True`` for ``example_number`` will allow for that field
-to be optional in the model form. The permissions in the class Meta (lines 15-20) are required for the
-TOM Toolkit to work properly. The ``hidden`` attribute can be set to ``True`` to hide the field from the target
-detail page.
+to be optional in the model form. Adding ``help_text=""`` to a field will provide text to be displayed under the form
+field when editing a target and in a tooltip when hovering over the field name on the target detail page. The
+permissions in the class Meta (lines 15-20) are required for the TOM Toolkit to work properly. The ``hidden``
+attribute can be set to ``True`` to hide the field from the target detail page.
 
 Reference the Django documentation on `Model Fields <https://docs.djangoproject.com/en/stable/ref/models/fields/#field-types>`__
 in order to learn more about Django models and their associated fields. The

--- a/tom_common/templatetags/tom_common_extras.py
+++ b/tom_common/templatetags/tom_common_extras.py
@@ -59,6 +59,14 @@ def verbose_name(instance, field_name):
     return instance._meta.get_field(field_name).verbose_name.title()
 
 
+@register.simple_tag
+def help_text(instance, field_name):
+    """
+    Displays the help text from a Django model field
+    """
+    return instance._meta.get_field(field_name).help_text
+
+
 @register.inclusion_tag('comments/list.html', takes_context=True)
 def recent_comments(context, limit=10):
     """

--- a/tom_targets/templates/tom_targets/partials/target_data.html
+++ b/tom_targets/templates/tom_targets/partials/target_data.html
@@ -10,7 +10,7 @@
   {% endfor %}
   {% for key, value in target.as_dict.items %}
     {% if value and key != 'name' %}
-      <dt class="col-sm-6">{% verbose_name target key %}</dt>
+      <dt class="col-sm-6" title="{% help_text target key %}">{% verbose_name target key %}</dt>
       <dd class="col-sm-6">{{ value|truncate_number }}</dd>
     {% endif %}
     {% if key == 'ra' %}


### PR DESCRIPTION
This will be the same text that is on the update form.
![image](https://github.com/user-attachments/assets/b5daf228-4369-492d-b881-7a53b88242bf)
