### PR TITLE
Add target creation form for updating an unknown target type.

### DIFF
--- a/tom_targets/forms.py
+++ b/tom_targets/forms.py
@@ -154,6 +154,18 @@ class NonSiderealTargetCreateForm(TargetForm):
                                         field.name not in SIDEREAL_FIELDS + IGNORE_FIELDS + NON_SIDEREAL_FIELDS]
 
 
+class UnknownTypeTargetCreateForm(TargetForm):
+    """If we don't know the type, this provides a generic Target Creation form that requires type to be set.
+    The only difference between this and the base TargetForm is that the 'type' field is required, and not hidden.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['type'].required = True
+
+    class Meta(TargetForm.Meta):
+        widgets = {}
+
+
 class TargetVisibilityForm(forms.Form):
     start_time = forms.DateTimeField(required=True, label='Start Time', widget=forms.TextInput(attrs={'type': 'date'}))
     end_time = forms.DateTimeField(required=True, label='End Time', widget=forms.TextInput(attrs={'type': 'date'}))

--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -35,7 +35,8 @@ from tom_observations.observation_template import ApplyObservationTemplateForm
 from tom_observations.models import ObservationTemplate
 from tom_targets.filters import TargetFilter
 from tom_targets.forms import SiderealTargetCreateForm, NonSiderealTargetCreateForm, TargetExtraFormset
-from tom_targets.forms import TargetNamesFormset, TargetShareForm, TargetListShareForm, TargetMergeForm
+from tom_targets.forms import TargetNamesFormset, TargetShareForm, TargetListShareForm, TargetMergeForm,\
+    UnknownTypeTargetCreateForm
 from tom_targets.sharing import share_target_with_tom
 from tom_targets.merge import target_merge
 from tom_dataproducts.sharing import (share_data_with_hermes, share_data_with_tom, sharing_feedback_handler,
@@ -312,6 +313,8 @@ class TargetUpdateView(Raise403PermissionRequiredMixin, UpdateView):
             return SiderealTargetCreateForm
         elif self.object.type == Target.NON_SIDEREAL:
             return NonSiderealTargetCreateForm
+        else:
+            return UnknownTypeTargetCreateForm
 
     def get_initial(self):
         """


### PR DESCRIPTION
This is a fix for an edge case of an edge case.

If a target is created in a way that bypasses validation, it can have no target type. 
In this case, the update form will be unset.

This change lets the user USE the update form to set a type rather than just catching an exception or keeping the pariah target floating around causing other problems. 