### PR TITLE
fix to use related_name rather than default _set for reverse relation…

### DIFF
--- a/tom_targets/base_models.py
+++ b/tom_targets/base_models.py
@@ -416,6 +416,7 @@ class BaseTarget(models.Model):
         :Keyword Arguments:
             * extras (`dict`): dictionary of key/value pairs representing target attributes
         """
+
         extras = kwargs.pop('extras', {})
         names = kwargs.pop('names', [])
 
@@ -435,7 +436,7 @@ class BaseTarget(models.Model):
             target_extra.save()
 
         for name in names:
-            name, _ = self.targetname_set.get_or_create(target=self, name=name)
+            name, _ = self.aliases.get_or_create(target=self, name=name)
             name.full_clean()
             name.save()
 

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -463,6 +463,19 @@ class TestTargetCreate(TestCase):
         for target_name in names:
             self.assertTrue(TargetName.objects.filter(target=target, name=target_name).exists())
 
+    def test_direct_creation_of_targets_with_multiple_names(self):
+        target_data = {
+            'name': 'multiple_names_target',
+            'type': Target.SIDEREAL,
+            'ra': 113.456,
+            'dec': -22.1}
+        names = ['John', 'Doe']
+        target = Target(**target_data)
+        target.save(names=names)
+        self.assertEqual(target.name, target_data['name'])
+        for target_name in names:
+            self.assertTrue(TargetName.objects.filter(target=target, name=target_name).exists())
+
     def test_create_targets_with_conflicting_names(self):
         target_data = {
             'name': 'multiple_names_target',


### PR DESCRIPTION
…ship

This was an error where we used the default relational name `targetname_set` instead of the `related_name`, "aliases" as defined [in the code](https://github.com/TOMToolkit/tom_base/blob/b0486a6fb68abb3c105447eaaaab354510f162ca/tom_targets/models.py#L47).