### PR TITLE
Infinite scroll on target list table using HTMX

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -972,6 +972,25 @@ asgiref = ">=3.6"
 django = ">=4.2"
 
 [[package]]
+name = "django-template-partials"
+version = "24.4"
+description = "django-template-partials"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "django_template_partials-24.4-py2.py3-none-any.whl", hash = "sha256:ee59d3839385d7f648907c3fa8d5923fcd66cd8090f141fe2a1c338b917984e2"},
+    {file = "django_template_partials-24.4.tar.gz", hash = "sha256:25b67301470fc274ecc419e5e5fd4686a5020b1c038fd241a70eb087809034b6"},
+]
+
+[package.dependencies]
+Django = "*"
+
+[package.extras]
+docs = ["Sphinx"]
+tests = ["coverage", "django_coverage_plugin"]
+
+[[package]]
 name = "djangorestframework"
 version = "3.15.2"
 description = "Web APIs for Django, made easy."
@@ -2913,4 +2932,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.0,<3.13"
-content-hash = "8720f742a36e2bf3b8b452260c73d83fa47b36d65204a9033fccec1b6410e27c"
+content-hash = "560d285138f66bcb86c9c9f541be766779c5ef7b6b48ceef262769d2a0284976"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "django-gravatar2 >=1.0.0,<2.0.0",
     "django-guardian >=2.0.0,<3.0.0",
     "django-htmx >=1.0.0,<2.0.0",
+    "django-template-partials>=24.4,<25.0",
     "fits2image >=0.4,<0.5",
     "markdown <4",
     "pillow >9.2,<12.0",

--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     'django_filters',
     'django_gravatar',
     'django_htmx',
+    'template_partials',
     'tom_targets',
     'tom_alerts',
     'tom_catalogs',

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     'django_filters',
     'django_gravatar',
     'django_htmx',
+    'template_partials',
     'tom_targets',
     'tom_alerts',
     'tom_catalogs',

--- a/tom_targets/templates/tom_targets/partials/target_table.html
+++ b/tom_targets/templates/tom_targets/partials/target_table.html
@@ -1,3 +1,4 @@
+{% load partials static tom_common_extras %}
 <table class="table table-hover">
   <thead>
     <tr>
@@ -19,8 +20,16 @@
     </tr>
   </thead>
   <tbody>
+    {% partialdef target-table-inline inline %}
     {% for target in targets %}
-    <tr>
+      {% if forloop.last and page_obj.has_next %}
+        <tr hx-get="{% url 'targets:list' %}{% querystring page=page_obj.next_page_number %}"
+            hx-trigger="revealed"
+            hx-swap="afterend"
+            hx-indicator=".htmx-indicator">
+      {% else %}
+        <tr>
+      {% endif %}
       <td>
         {% if all_checked %}
           <input type="checkbox" name="selected-target" value="{{ target.id }}" onClick="single_select()" form="grouping-form" checked/>
@@ -61,5 +70,9 @@
       </td>
     </tr>
     {% endfor %}
+    {% endpartialdef %}
   </tbody>
 </table>
+<center>
+  <img class="htmx-indicator" width="60" src="{% static 'tom_common/img/bluespinner.gif' %}">
+</center>

--- a/tom_targets/templates/tom_targets/target_list.html
+++ b/tom_targets/templates/tom_targets/target_list.html
@@ -23,8 +23,7 @@
       </div>
     </div>
     {% select_target_js %}
-    {% aladin_skymap object_list %}
-    {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
+    {% aladin_skymap targets %}
     <label id="displaySelected"></label>
     <button id="optionSelectAll" type="button" class="btn btn-link" onClick="select_all({{ target_count }})"></button>
     <form id="grouping-form" action="{% url 'targets:add-remove-grouping' %}" method="POST">
@@ -47,8 +46,7 @@
         <button type="submit" class="btn btn-outline-danger ml-1" name="remove">Remove</button>
       </div>
     </form>
-    {% target_table object_list %}
-    {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
+    {% target_table targets %}
   </div>
   {{ filter.fields }}
   <div class="col-md-2">

--- a/tom_targets/templatetags/targets_extras.py
+++ b/tom_targets/templatetags/targets_extras.py
@@ -367,14 +367,10 @@ def target_table(context, targets, all_checked=False):
     Returns a partial for a table of targets, used in the target_list.html template
     by default
     """
-
-    return {
-        'targets': targets,
-        'all_checked': all_checked,
-        'empty_database': context['empty_database'],
-        'authenticated': context['request'].user.is_authenticated,
-        'query_string': context['query_string']
-    }
+    context['targets'] = targets
+    context['all_checked'] = all_checked
+    context['authenticated'] = context['request'].user.is_authenticated,
+    return context
 
 
 @register.inclusion_tag('tom_targets/partials/persistent_share_table.html', takes_context=True)

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -40,6 +40,15 @@ class TestTargetListUserPermissions(TestCase):
         self.assertContains(response, self.st1.name)
         self.assertContains(response, self.st2.name)
 
+    def test_list_targets_partial(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('targets:list'), headers={'HX-Request': 'true'})
+        # The following assertion is a hack until django-template-partials is merged into django
+        # https://github.com/carltongibson/django-template-partials/issues/54#issuecomment-2316852787
+        self.assertNotContains(response, '<tbody>')
+        self.assertContains(response, self.st1.name)
+        self.assertContains(response, self.st2.name)
+
     def test_list_targets_limited_permissions(self):
         self.client.force_login(self.user2)
         response = self.client.get(reverse('targets:list'))

--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -74,6 +74,7 @@ class TargetListView(PermissionListMixin, FilterView):
     # Set app_name for Django-Guardian Permissions in case of Custom Target Model
     permission_required = f'{Target._meta.app_label}.view_target'
     ordering = ['-created']
+    context_object_name = 'targets'
 
     def get_context_data(self, *args, **kwargs):
         """
@@ -92,6 +93,11 @@ class TargetListView(PermissionListMixin, FilterView):
                                 else TargetList.objects.none())
         context['query_string'] = self.request.META['QUERY_STRING']
         return context
+
+    def get_template_names(self) -> list[str]:
+        if self.request.htmx:
+            return ['tom_targets/partials/target_table.html#target-table-inline']
+        return super().get_template_names()
 
 
 class TargetNameSearchView(RedirectView):


### PR DESCRIPTION
Here is how infinite scroll might work using HTMX.

The django-template-partials dependency is on track to be included in Django, hopefully in time for the 5.2 release.
https://github.com/carltongibson/django-template-partials/issues/29

The `querystring` template tag added to `tom_common_extras` is taken directly from Django 5.1, so once `tom_base` is upraded to 5.1 the entire tag can simply be removed.

What's left isn't much! There were some changes required because of using a tag for the target table instead of a template include, but nothing too crazy.

The select some/select all checkbox remains broken in the same way it is before this change, so that can be addressed in another PR.


https://github.com/user-attachments/assets/63e49a75-e85f-4182-b6bb-637c003527aa

