### PR TITLE
1187 aladin skymap blocking load catalog per target

### DIFF
--- a/tom_targets/filters.py
+++ b/tom_targets/filters.py
@@ -130,6 +130,13 @@ class TargetFilter(django_filters.FilterSet):
         }
     )
 
+    limit = django_filters.NumberFilter(label="Result Limit", method='filter_limit')
+
+    def filter_limit(self, queryset, name, value):
+        if value is not None:
+            return queryset[:value]
+        return queryset
+
     class Meta:
         model = Target
         fields = ['type', 'name', 'key', 'value', 'cone_search', 'targetlist__name']

--- a/tom_targets/templates/tom_targets/partials/aladin_skymap.html
+++ b/tom_targets/templates/tom_targets/partials/aladin_skymap.html
@@ -1,7 +1,25 @@
 <!-- embedding Aladin Lite example code found at: https://aladin.cds.unistra.fr/AladinLite/doc/  -->
-<div id="aladin-lite-div" style="width:auto; height:700px; margin:auto; margin-top: 20px;" ></div>
-
+{% load bootstrap4 tom_common_extras %}
+<div id="aladin-target-warning" class="d-none mt-2">
+{% bootstrap_alert "Map display will be limited to 10,000 randomly sampled targets" alert_type="warning" %}
+</div>
+<div id="aladin-lite-div" style="width:auto; height:450px; margin:auto; margin-top: 10px;" ></div>
 <script type="text/javascript">
+async function fetchAladinTargets() {
+  const url = "{% url 'tom_targets:aladin' %}{% querystring %}".replace("&amp;", "&");
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error("Failed to fetch Aladin targets");
+    }
+
+    const jsonTargets = await response.json();
+    return jsonTargets.targets;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
 (async function loadAladin() {
     const scriptKey = "cachedAladinJS";
 
@@ -28,6 +46,16 @@
         console.log("Fetched aladin.js and saved to sessionStorage");
     }
 
+    // Fetch the targets
+    const targets = await fetchAladinTargets();
+    const largeTargetsWarning = document.getElementById("aladin-target-warning");
+    // Display a warning if there are too many targets to display on the map at once.
+    if (targets.length >= 10000) {
+      largeTargetsWarning.classList.remove("d-none");
+    } else {
+      largeTargetsWarning.classList.add("d-none");
+    }
+
     // Initialize Aladin after script loads
 
     A.init.then(() => {
@@ -42,23 +70,19 @@
 
         aladin.setCooGrid({ color: 'grey', labelSize: 10 });
 
-        // extract the targets from the context
-        var targets = {{ targets|safe }}; //targets cannot be a queryset; here it is a list of dictionaries
-
         // define catalog for the targets
         var catalogOptions = {
             name: 'Targets',
             color: 'blue',
             sourceSize: 16};
 
-        // add targets to the catalog
-        for (var i = 0; i < targets.length; i++) {
-            var target = targets[i];
-            var targetCatalog = A.catalog({name: target.name , color: 'blue', sourceSize: 16});
-            aladin.addCatalog(targetCatalog);
-            popupInfo = ['RA: '.concat(target.ra, '<br>',  'Dec: ', target.dec)];
-            targetCatalog.addSources([A.marker(target.ra, target.dec, {popupTitle: target.name, popupDesc: popupInfo})]);
-        }
+        const targetCatalog = A.catalog({name: "Targets" , color: 'blue', sourceSize: 16});
+        const markers = targets.map(target =>{
+          const popupInfo = ['RA: '.concat(target.ra, '<br>',  'Dec: ', target.dec)];
+          return A.marker(target.ra, target.dec, {popupTitle: target.name, popupDesc: popupInfo})
+        });
+        targetCatalog.addSources(markers);
+        aladin.addCatalog(targetCatalog);
 
         // extract Moon information from the context
         const moonRaDeg = {{ moon_ra|safe }};

--- a/tom_targets/templates/tom_targets/partials/aladin_skymap.html
+++ b/tom_targets/templates/tom_targets/partials/aladin_skymap.html
@@ -6,7 +6,8 @@
 <div id="aladin-lite-div" style="width:auto; height:450px; margin:auto; margin-top: 10px;" ></div>
 <script type="text/javascript">
 async function fetchAladinTargets() {
-  const url = "{% url 'tom_targets:aladin' %}{% querystring %}".replace("&amp;", "&");
+  {% querystring as params %}
+  const url = "{% url 'tom_targets:aladin' %}{{ params|safe }}";
   try {
     const response = await fetch(url);
     if (!response.ok) {
@@ -48,8 +49,9 @@ async function fetchAladinTargets() {
 
     // Fetch the targets
     const targets = await fetchAladinTargets();
-    const largeTargetsWarning = document.getElementById("aladin-target-warning");
+
     // Display a warning if there are too many targets to display on the map at once.
+    const largeTargetsWarning = document.getElementById("aladin-target-warning");
     if (targets.length >= 10000) {
       largeTargetsWarning.classList.remove("d-none");
     } else {
@@ -76,6 +78,7 @@ async function fetchAladinTargets() {
             color: 'blue',
             sourceSize: 16};
 
+        // One catalog for all targets. The map becomes unstable at ~200 catalogs.
         const targetCatalog = A.catalog({name: "Targets" , color: 'blue', sourceSize: 16});
         const markers = targets.map(target =>{
           const popupInfo = ['RA: '.concat(target.ra, '<br>',  'Dec: ', target.dec)];

--- a/tom_targets/templates/tom_targets/target_list.html
+++ b/tom_targets/templates/tom_targets/target_list.html
@@ -23,7 +23,7 @@
       </div>
     </div>
     {% select_target_js %}
-    {% aladin_skymap targets %}
+    {% aladin_skymap %}
     <label id="displaySelected"></label>
     <button id="optionSelectAll" type="button" class="btn btn-link" onClick="select_all({{ target_count }})"></button>
     <form id="grouping-form" action="{% url 'targets:add-remove-grouping' %}" method="POST">

--- a/tom_targets/templatetags/targets_extras.py
+++ b/tom_targets/templatetags/targets_extras.py
@@ -285,7 +285,7 @@ def aladin_finderchart(target):
 
 
 @register.inclusion_tag('tom_targets/partials/aladin_skymap.html')
-def aladin_skymap(targets):
+def aladin_skymap():
     """
     Displays aladin skyview on Target Distribution skymap. Markers on the skymap show where your targets are. Max of
     25 targets show at a time (one page of targets). This templatetag converts the targets queryset into a list of
@@ -293,13 +293,6 @@ def aladin_skymap(targets):
 
     Also, puts the current Moon and Sun positions (from astropy) into the context.
     """
-    target_list = []
-    for target in targets:
-        if target.type == Target.SIDEREAL:
-            name = target.name
-            ra = target.ra
-            dec = target.dec
-            target_list.append({'name': name, 'ra': ra, 'dec': dec})
 
     # To display the Moon and Sun on the skymap, calculate postions for
     # them here and pass them to the template in the context
@@ -309,7 +302,6 @@ def aladin_skymap(targets):
     sun_pos = get_body('sun', now)
 
     context = {
-        'targets': target_list,
         'moon_ra': moon_pos.ra.deg,
         'moon_dec': moon_pos.dec.deg,
         'moon_illumination': moon_illum,

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -1955,3 +1955,26 @@ class TestTargetSeed(TestCase):
         response = self.client.post(reverse('targets:seed'))
         self.assertEqual(response.status_code, 302)
         self.assertFalse(Target.objects.exists())
+
+
+class TestAladinTargetView(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='testuser')
+        self.client.force_login(self.user)
+        self.st = SiderealTargetFactory.create()
+        self.ns = NonSiderealTargetFactory.create()
+        assign_perm('tom_targets.view_target', self.user, self.st)
+        assign_perm('tom_targets.view_target', self.user, self.ns)
+
+    def test_aladin_response(self):
+        response = self.client.get(reverse('targets:aladin'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()['targets']), 2)
+        self.assertContains(response, self.st.name)
+
+    def test_aladin_filter(self):
+        response = self.client.get(reverse('targets:aladin') + '?name=' + self.st.name)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()['targets']), 1)
+        self.assertContains(response, self.st.name)
+        self.assertNotContains(response, self.ns.name)

--- a/tom_targets/urls.py
+++ b/tom_targets/urls.py
@@ -6,7 +6,7 @@ from .views import (TargetGroupingView, TargetGroupingDeleteView, TargetGrouping
                     TargetAddRemoveGroupingView, TargetMergeView, TargetPersistentShareManageFormView,
                     PersistentShareManageFormView, TargetPersistentShareManageTable, PersistentShareManageTable)
 from .views import TargetGroupingShareView, TargetHermesPreloadView, TargetGroupingHermesPreloadView
-from .views import TargetSeedView
+from .views import TargetSeedView, AladinTargetListView
 from .viewsets import PersistentShareViewSet
 
 from .api_views import TargetViewSet, TargetExtraViewSet, TargetNameViewSet, TargetListViewSet
@@ -22,6 +22,7 @@ app_name = 'tom_targets'
 
 urlpatterns = [
     path('', TargetListView.as_view(), name='list'),
+    path('aladin/', AladinTargetListView.as_view(), name='aladin'),
     path('targetgrouping/', TargetGroupingView.as_view(), name='targetgrouping'),
     path('create/', TargetCreateView.as_view(), name='create'),
     path('import/', TargetImportView.as_view(), name='import'),


### PR DESCRIPTION
Uses a dedicated JSON endpoint to load targets for the Aladin map, making it efficient enough that _all_ (well, up to 10k) targets that match a filter can be displayed on the map, instead of only the 25 in the current pagination page. This is much more intuitive and what I'd expect to see on the map.

The 10k number can be adjusted but at that point there's so many targets that it's not worth adding more as you won't really be able to see a difference.

This is important because with infinite scroll, it's not possible to keep what is displayed on the Aladin map consistent with the current "page". 

Fixes [#1187](https://github.com/TOMToolkit/tom_base/issues/1187)

https://github.com/user-attachments/assets/e7413d70-95bd-45b9-8cc7-e6aeb06cd706

