### PR TITLE
Only show target lists user has access to

### DIFF
--- a/tom_targets/forms.py
+++ b/tom_targets/forms.py
@@ -271,7 +271,7 @@ class PersistentShareForm(AdminPersistentShareForm):
 
 
 class TargetListForm(forms.ModelForm):
-    groups = forms.ModelMultipleChoiceField(
+    user_groups = forms.ModelMultipleChoiceField(
         Group.objects.none(),
         required=False,
         widget=forms.CheckboxSelectMultiple,
@@ -280,4 +280,4 @@ class TargetListForm(forms.ModelForm):
 
     class Meta:
         model = TargetList
-        fields = ['name', 'groups']
+        fields = ['name', 'user_groups']

--- a/tom_targets/forms.py
+++ b/tom_targets/forms.py
@@ -268,3 +268,16 @@ class PersistentShareForm(AdminPersistentShareForm):
         if self.target_id:
             self.fields['target'].initial = self.target_id
             self.fields['target'].disabled = True
+
+
+class TargetListForm(forms.ModelForm):
+    groups = forms.ModelMultipleChoiceField(
+        Group.objects.none(),
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        help_text='Select groups to share this target list with.'
+    )
+
+    class Meta:
+        model = TargetList
+        fields = ['name', 'groups']

--- a/tom_targets/templates/tom_targets/targetlist_form.html
+++ b/tom_targets/templates/tom_targets/targetlist_form.html
@@ -2,8 +2,16 @@
 {% load bootstrap4 %}
 {% block title %}New Target Group{% endblock %}
 {% block content %}
-<form method="post">{% csrf_token %}
-    {{ form.as_p }}
-    <input type="submit" value="Create">
-</form>
+<h3>Create Target Grouping</h3>
+<div class="row">
+  <div class="col-md-6">
+    <form method="post">
+        {% csrf_token %}
+        {% bootstrap_form form %}
+        {% buttons %}
+            <button type="submit" class="btn btn-primary">Save</button>
+        {% endbuttons %}
+    </form>
+  </div>
+</div>
 {% endblock %}

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -1155,13 +1155,12 @@ class TestTargetGrouping(TestCase):
         self.assertTrue(TargetList.objects.filter(name=group_data['name']).exists())
 
     def test_create_target_list_with_user_group(self):
-        # so many groups, this is extremely confusing.
         user_group = Group.objects.create(name="targetlist_test")
         perm_checker = ObjectPermissionChecker(user_group)
         self.user.groups.add(user_group)
         group_data = {
             'name': 'test_target_list',
-            'groups': [user_group.pk]
+            'user_groups': [user_group.pk]
         }
         response = self.client.post(reverse('targets:create-group'), data=group_data)
         targetlist = TargetList.objects.get(name=group_data['name'])

--- a/tom_targets/urls.py
+++ b/tom_targets/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from .views import TargetCreateView, TargetUpdateView, TargetDetailView, TargetNameSearchView
 from .views import TargetDeleteView, TargetListView, TargetImportView, TargetExportView, TargetShareView
-from .views import (TargetGroupingView, TargetGroupingDeleteView, TargetGroupingCreateView,
+from .views import (TargetGroupingView, TargetGroupingDeleteView, TargetListCreateView,
                     TargetAddRemoveGroupingView, TargetMergeView, TargetPersistentShareManageFormView,
                     PersistentShareManageFormView, TargetPersistentShareManageTable, PersistentShareManageTable)
 from .views import TargetGroupingShareView, TargetHermesPreloadView, TargetGroupingHermesPreloadView
@@ -36,7 +36,7 @@ urlpatterns = [
     path('<int:pk>/hermes-preload/', TargetHermesPreloadView.as_view(), name='hermes-preload'),
     path('<int:pk>/', TargetDetailView.as_view(), name='detail'),
     path('targetgrouping/<int:pk>/delete/', TargetGroupingDeleteView.as_view(), name='delete-group'),
-    path('targetgrouping/create/', TargetGroupingCreateView.as_view(), name='create-group'),
+    path('targetgrouping/create/', TargetListCreateView.as_view(), name='create-group'),
     path('targetgrouping/<int:pk>/share/', TargetGroupingShareView.as_view(), name='share-group'),
     path('targetgrouping/<int:pk>/hermes-preload/', TargetGroupingHermesPreloadView.as_view(),
          name='group-hermes-preload'),

--- a/tom_targets/views.py
+++ b/tom_targets/views.py
@@ -771,7 +771,7 @@ class TargetGroupingDeleteView(Raise403PermissionRequiredMixin, DeleteView):
     success_url = reverse_lazy('targets:targetgrouping')
 
 
-class TargetGroupingCreateView(LoginRequiredMixin, CreateView):
+class TargetListCreateView(LoginRequiredMixin, CreateView):
     """
     View that handles the creation of ``TargetList`` objects, also known as target groups. Requires authentication.
     """
@@ -781,12 +781,12 @@ class TargetGroupingCreateView(LoginRequiredMixin, CreateView):
 
     def get_form(self, *args, **kwargs):
         form = super().get_form(*args, **kwargs)
-        form.fields['groups'].queryset = self.request.user.groups.all()
+        form.fields['user_groups'].queryset = self.request.user.groups.all()
         return form
 
     def form_valid(self, form):
         """
-        Runs after form validation. Saves the target group and assigns the user and group permissions to the group.
+        Runs after form validation. Saves the target list and assigns the user and group permissions to the list.
 
         :param form: Form data for target creation
         :type form: django.forms.ModelForm
@@ -797,10 +797,10 @@ class TargetGroupingCreateView(LoginRequiredMixin, CreateView):
         assign_perm('tom_targets.change_targetlist', self.request.user, obj)
         assign_perm('tom_targets.delete_targetlist', self.request.user, obj)
 
-        for group in form.cleaned_data['groups']:
-            assign_perm('tom_targets.view_targetlist', group, obj)
-            assign_perm('tom_targets.change_targetlist', group, obj)
-            assign_perm('tom_targets.delete_targetlist', group, obj)
+        for user_group in form.cleaned_data['user_groups']:
+            assign_perm('tom_targets.view_targetlist', user_group, obj)
+            assign_perm('tom_targets.change_targetlist', user_group, obj)
+            assign_perm('tom_targets.delete_targetlist', user_group, obj)
         return super().form_valid(form)
 
 


### PR DESCRIPTION
This commit solves the issue where on the target list page, the target list dropdown for bulk operations shows all target lists on the TOM, not just the ones the user has access too.

Additionally, this commit adds the option to select groups for which a newly created target list belongs to, giving users of those groups access to it.

Fixes #1141