### PR TITLE
move DRF create_auth_token signal receiver to signals

### DIFF
--- a/tom_common/models.py
+++ b/tom_common/models.py
@@ -1,15 +1,5 @@
-from django.conf import settings
-from django.db.models.signals import post_save
 from django.db import models
-from django.dispatch import receiver
 from django.contrib.auth.models import User
-from rest_framework.authtoken.models import Token
-
-
-@receiver(post_save, sender=settings.AUTH_USER_MODEL)
-def create_auth_token(sender, instance=None, created=False, **kwargs):
-    if created:
-        Token.objects.create(user=instance)
 
 
 class Profile(models.Model):

--- a/tom_common/signals.py
+++ b/tom_common/signals.py
@@ -1,14 +1,26 @@
 import logging
 
+from django.conf import settings
+
 from django.db.models.signals import post_save
 from django.contrib.auth.models import User
 from django.dispatch import receiver
+
+from rest_framework.authtoken.models import Token
 
 from tom_common.models import Profile
 
 logger = logging.getLogger(__name__)
 
 
+# Signal: create DRF token for new users
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    if created:
+        Token.objects.create(user=instance)
+
+
+# Signal: create Profile for new users
 @receiver(post_save, sender=User)
 def save_profile(sender, instance, **kwargs):
     """When a user is saved, save their profile."""


### PR DESCRIPTION
refactors signal receiver out of models.py to signals.py consistent with Django docs recommendation. See
https://docs.djangoproject.com/en/5.1/topics/signals/