### PR TITLE
use updated fuzzy_name match

### DIFF
--- a/tom_targets/base_models.py
+++ b/tom_targets/base_models.py
@@ -160,12 +160,13 @@ class TargetMatchManager(models.Manager):
         queryset = super().get_queryset().filter(name=name)
         return queryset
 
-    def match_fuzzy_name(self, name):
+    def match_fuzzy_name(self, name, input_queryset=None):
         """
         Returns a queryset of targets with a name OR ALIAS that, when processed by ``simplify_name``, match a similarly
         processed version of the name that is received.
 
         :param name: The string against which target names and aliases will be matched.
+        :param input_queryset: Optional queryset to filter the results. If not provided, all targets will be considered.
 
         :return: queryset containing matching Targets. Will return targets even when matched value is an alias.
         """
@@ -175,7 +176,8 @@ class TargetMatchManager(models.Manager):
             for alias in target.names:
                 if self.simplify_name(alias) == simple_name:
                     matching_names.append(target.name)
-        queryset = self.get_queryset().filter(name__in=matching_names)
+        initial_queryset = input_queryset or self.get_queryset()
+        queryset = initial_queryset.filter(name__in=matching_names)
         return queryset
 
     def simplify_name(self, name):

--- a/tom_targets/filters.py
+++ b/tom_targets/filters.py
@@ -3,7 +3,6 @@ from django.db.models import Q
 import django_filters
 
 from tom_targets.models import Target, TargetList
-from tom_targets.base_models import TargetMatchManager
 from tom_targets.utils import cone_search_filter
 
 

--- a/tom_targets/filters.py
+++ b/tom_targets/filters.py
@@ -71,14 +71,7 @@ class TargetFilter(django_filters.FilterSet):
         Return a queryset for targets with names or aliases fuzzy matching the given coma-separated list of terms.
         A fuzzy match is determined by the `make_simple_name` method of the `TargetMatchManager` class.
         """
-        matching_names = []
-        for term in value.split(','):
-            simple_name = TargetMatchManager.make_simple_name(self, term)
-            for target in Target.objects.all().prefetch_related('aliases'):
-                for alias in target.names:
-                    if TargetMatchManager.make_simple_name(self, alias) == simple_name:
-                        matching_names.append(target.name)
-        return queryset.filter(name__in=matching_names).distinct()
+        return Target.matches.match_fuzzy_name(value, queryset).distinct()
 
     cone_search = django_filters.CharFilter(method='filter_cone_search', label='Cone Search',
                                             help_text='RA, Dec, Search Radius (degrees)')


### PR DESCRIPTION
This is a simplification for filters to use the existing match filter for fuzzy name matching.

This bug was introduced a while ago with a refactor, and got missed.