### PR TITLE
Fix for the MPC Harvester designation changes

### DIFF
--- a/tom_catalogs/harvesters/mpc.py
+++ b/tom_catalogs/harvesters/mpc.py
@@ -71,11 +71,23 @@ class MPCExplorerHarvester(AbstractHarvester):
         target.type = 'NON_SIDEREAL'
         target.scheme = 'MPC_COMET'
 
-        target.name = result['designation_data']['iau_designation'].replace('(', '').replace(')', '')
+        unpacked_primary_desig = result['designation_data']['unpacked_primary_provisional_designation']
+        orbfit_name = result['designation_data']['orbfit_name']
+        # If the unpacked primary designation (minus any spaces in the middle) is the same as the orbfit_name,
+        # then we have a provisional-only and no permanent designation. In this case, set the target's name
+        # to the unpacked primary designation (with the space). Otherwise we have a permanent desigination,
+        # and it's safe (hopefully) to use the orbfit_name without having to unpack into year & half-month plus
+        # running designation
+        target_name = None
+        if unpacked_primary_desig.replace(' ', '') == orbfit_name:
+            target_name = unpacked_primary_desig
+        else:
+            target_name = orbfit_name
+        target.name = target_name
         extra_desigs = []
         if result['designation_data'].get('name', "") != "":
             extra_desigs.append(result['designation_data']['name'])
-        extra_desigs.append(result['designation_data']['unpacked_primary_provisional_designation'])
+        extra_desigs.append(unpacked_primary_desig)
         extra_desigs += result['designation_data']['unpacked_secondary_provisional_designations']
         # Make sure we don't include the primary designation twice
         try:

--- a/tom_catalogs/tests/harvesters/data/test_65803_mpc_orb.json
+++ b/tom_catalogs/tests/harvesters/data/test_65803_mpc_orb.json
@@ -192,15 +192,10 @@
         "orbit_type_str": "Inner Solar System"
     },
     "designation_data": {
-        "designation_count": 0,
-        "found": 1,
-        "iau_designation": "(65803)",
+        "designation_count": 1,
         "iau_name": "",
         "name": "Didymos",
-        "new_style_packed_permid": "000065803",
-        "new_style_packed_primary_provisional_designation": "J96G00000T",
         "orbfit_name": "65803",
-        "packed_permid": "65803",
         "packed_primary_provisional_designation": "J96G00T",
         "packed_secondary_provisional_designations": [],
         "permid": "65803",

--- a/tom_catalogs/tests/harvesters/test_mpc.py
+++ b/tom_catalogs/tests/harvesters/test_mpc.py
@@ -52,10 +52,9 @@ class TestMPCExplorerHarvester(TestCase):
 
     def test_to_target_no_name(self):
         # Modify designation data to one with a provisional id only
-        self.broker.catalog_data[0]['mpc_orb']['designation_data']['iau_designation'] = "2025 AA"
         self.broker.catalog_data[0]['mpc_orb']['designation_data']['iau_name'] = ""
         del (self.broker.catalog_data[0]['mpc_orb']['designation_data']['name'])
-        self.broker.catalog_data[0]['mpc_orb']['designation_data']['orbfit_name'] = "2025 AA"
+        self.broker.catalog_data[0]['mpc_orb']['designation_data']['orbfit_name'] = "2025AA"
         self.broker.catalog_data[0]['mpc_orb']['designation_data']['unpacked_primary_provisional_designation'] = \
             "2025 AA"
         self.broker.catalog_data[0]['mpc_orb']['designation_data']['unpacked_secondary_provisional_designations'] = []
@@ -69,7 +68,6 @@ class TestMPCExplorerHarvester(TestCase):
 
     def test_to_target_multiple_alternative_desigs(self):
         # Modify designation data to one with a provisional id only
-        self.broker.catalog_data[0]['mpc_orb']['designation_data']['iau_designation'] = "(709)"
         self.broker.catalog_data[0]['mpc_orb']['designation_data']['iau_name'] = ""
         self.broker.catalog_data[0]['mpc_orb']['designation_data']['name'] = 'Fringilla'
         self.broker.catalog_data[0]['mpc_orb']['designation_data']['orbfit_name'] = "709"


### PR DESCRIPTION
This fixes the MPC Harvester for the changes in fields used to make the `target` name. Fixes #1244 