### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,9 @@ name: run-tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TOMToolkit/tom_base/security/code-scanning/17](https://github.com/TOMToolkit/tom_base/security/code-scanning/17)

To fix the problem, we need to introduce an explicit `permissions` block at the root of the workflow, ensuring that the least privilege principle is enforced. Since the workflow involves linting, testing, and publishing coverage, we will set the `contents: read` permission globally as these jobs do not require write permissions to the repository. Additionally, the `publish_coverage` job requires the `secrets.GITHUB_TOKEN` for reporting coverage, but no write permissions are necessary for this functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
