### PR TITLE
Add setting for default permissions on Target

### DIFF
--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -308,6 +308,9 @@ AUTH_STRATEGY = 'READ_ONLY'
 # `ObservationRecord`, `DataProduct`, and `ReducedDatum` objects.
 TARGET_PERMISSIONS_ONLY = True
 
+# Default permission for newly created targets. Values can be 'PRIVATE', 'PUBLIC', or 'OPEN'
+TARGET_DEFAULT_PERMISSION = 'PRIVATE'
+
 # URLs that should be allowed access even with AUTH_STRATEGY = LOCKED
 # for example: OPEN_URLS = ['/', '/about']
 OPEN_URLS = []

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -320,6 +320,9 @@ AUTH_STRATEGY = 'READ_ONLY'
 # `ObservationRecord`, `DataProduct`, and `ReducedDatum` objects.
 TARGET_PERMISSIONS_ONLY = True
 
+# Default permission for newly created targets. Values can be 'PRIVATE', 'PUBLIC', or 'OPEN'
+TARGET_DEFAULT_PERMISSION = 'PRIVATE'
+
 # URLs that should be allowed access even with AUTH_STRATEGY = LOCKED
 # for example: OPEN_URLS = ['/', '/about']
 OPEN_URLS = []

--- a/tom_targets/base_models.py
+++ b/tom_targets/base_models.py
@@ -193,6 +193,13 @@ class TargetMatchManager(models.Manager):
         return name.lower().replace(" ", "").replace("-", "").replace("_", "").replace("(", "").replace(")", "")
 
 
+def get_default_target_permission():
+    try:
+        return settings.TARGET_DEFAULT_PERMISSION
+    except AttributeError:
+        return BaseTarget.Permissions.PRIVATE
+
+
 class BaseTarget(models.Model):
     """
     Class representing a target in a TOM
@@ -314,7 +321,7 @@ class BaseTarget(models.Model):
         help_text='The time which this target was changed in the TOM database.'
     )
     permissions = models.CharField(
-        max_length=100, default=Permissions.PRIVATE, choices=Permissions.choices,
+        max_length=100, default=get_default_target_permission, choices=Permissions.choices,
         help_text='The access level of this target, see the docs on public vs private targets.'
     )
     ra = models.FloatField(

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -305,6 +305,11 @@ class TestTargetCreate(TestCase):
         target = Target.objects.get(name=target_data['name'])
         self.assertTrue(target.targetextra_set.filter(key='category', value='type2').exists())
 
+    @override_settings(TARGET_DEFAULT_PERMISSION='OPEN')
+    def test_create_target_configurable_permissions(self):
+        target = Target.objects.create(name='test_target', type=Target.SIDEREAL, ra='83.6', dec='30.21')
+        self.assertEqual(target.permissions, 'OPEN')
+
     @override_settings(EXTRA_FIELDS=[
         {'name': 'wins', 'type': 'number', 'default': '12'},
         {'name': 'checked', 'type': 'boolean'},


### PR DESCRIPTION
Configurable so that individual implementations don't need to explicitly set the permissions default everywhere a target is created.