### PR TITLE
Add documentation for encrypted fields

### DIFF
--- a/docs/customization/encrypted_model_fields.rst
+++ b/docs/customization/encrypted_model_fields.rst
@@ -7,8 +7,9 @@ sensitive data, then you may want to encrypt that data.
 Examples of user-specific sensitive
 data include a password or API key for an external service that your TOM uses.
 For example, TOMToolkit Facility modules can use the mechanism described here to store,
-encrypted, user-specific credentials in a user profile model. Examples include
-the ``tom_eso`` and the ``tom_swift`` facility modules.
+encrypted, user-specific credentials in a user profile model. Examples include the
+`tom_eso <https://github.com/TOMToolkit/tom_eso>`__ and the
+`tom_swift <https://github.com/TOMToolkit/tom_swift>`__ facility modules.
 
 As we explain below, TOMToolkit provides a *_mix-in_* class, a *property descriptor*, and
 utility functions to help encrypt user-specific sensitive data and access it when it's needed.

--- a/docs/customization/encrypted_model_fields.rst
+++ b/docs/customization/encrypted_model_fields.rst
@@ -6,7 +6,7 @@ sensitive data, then you may want to encrypt that data.
 
 Examples of user-specific sensitive
 data include a password or API key for an external service that your TOM uses.
-For example, TOMToolkit Facility modules can use the mechanim described here to store,
+For example, TOMToolkit Facility modules can use the mechanism described here to store,
 encrypted, user-specific credentials in a user profile model. Examples include
 the ``tom_eso`` and (soon) the ``tom_swift`` facility modules.
 
@@ -19,8 +19,8 @@ that this data be stored outside the TOM and accessed through environment variab
 Quick Start
 -----------
 
-Creating an encryted Model field
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Creating an encrypted Model field
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If your Model has a field that should be encrypted, follow these steps:
 
@@ -37,8 +37,8 @@ If your Model has a field that should be encrypted, follow these steps:
     class MyAppModel(EncryptableModelMixin, models.Model):
         ...
 
-This gives your model access to a set of methods that will manage the encyption and
-decyption of your data into and out of the ``BinaryField`` that stores the encrypted data.
+This gives your model access to a set of methods that will manage the encryption and
+decryption of your data into and out of the ``BinaryField`` that stores the encrypted data.
 
 3. Add the ``BinaryField`` that will store the encrypted data and the property descriptor
 through which the ``BinaryField`` will be accessed.
@@ -51,7 +51,7 @@ through which the ``BinaryField`` will be accessed.
 By convention name of the ``BinaryField`` field should begin with and underscore
 (``_ciphertext_api_key`` in our example) because is it private to the Model class.
 
-Accessing encrytped data
+Accessing encrypted data
 ~~~~~~~~~~~~~~~~~~~~~~~~
 The following example shows how to get and set an encrypted field using the utility
 methods provided in ``tom_common.session_utils.py``:
@@ -71,33 +71,33 @@ methods provided in ``tom_common.session_utils.py``:
     set_encrypted_field(user, profile, 'api_key', new_api_key)
 
 Note here that the User instance (``user``) is used to access the ``EncryptableModelMixin``
-subclass and it's encrypted data. The ``user`` property of the encrypted field-containing
+subclass and its encrypted data. The ``user`` property of the encrypted field-containing
 Model subclass (``MyAppModel`` in our example) is provided by the ``EncryptableModelMixin``.
-As such, the model *should not define a* ``user`` *property of it's own*.
+As such, the model *should not define a* ``user`` *property of its own*.
 
-Some Explainations
--------------------
+Some Explanations
+-----------------
 
 EncryptableModelMixin
 ~~~~~~~~~~~~~~~~~~~~~
 The User's data is encrypted using (among other things) their password (i.e the
 password they use to login to your TOM). When the User changes their password,
-their encrypted data reencrtyped accordingly. The ``EncryptableModelMixin`` adds
+their encrypted data re-encrypted accordingly. The ``EncryptableModelMixin`` adds
 method for this to your otherwise normal Django model.
 
 EncryptedProperty
 ~~~~~~~~~~~~~~~~~
 A *property descriptor* implements the Python descriptor protocol (``__get__``,
 ``__set__``, etc). The ``EncryptedProperty`` property descriptor handles the details
-of decrypting the encrypted ``BinaryField`` on it's way out of the database and
-encrypting it on the way in. It is invoked when the propetry is accessed
+of decrypting the encrypted ``BinaryField`` on its way out of the database and
+encrypting it on the way in. It is invoked when the property is accessed
 (e.g. ``model_instance.api_key``).
 
 Session Utils
 ~~~~~~~~~~~~~
 The ``get_encrypted_field`` and ``set_encrypted_field`` functions implement
 boilerplate code for creating and destroying the cipher used to encrypt and
-decypt the ``BinaryField``. *These methods must always be used to access any
+decrypt the ``BinaryField``. *These methods must always be used to access any
 encrypted field*.
 
 

--- a/docs/customization/encrypted_model_fields.rst
+++ b/docs/customization/encrypted_model_fields.rst
@@ -14,8 +14,9 @@ encrypted, user-specific credentials in a user profile model. Examples include t
 As we explain below, TOMToolkit provides a *_mix-in_* class, a *property descriptor*, and
 utility functions to help encrypt user-specific sensitive data and access it when it's needed.
 
-NOTE: For sensitive data that is used by the TOM itself and is not user-specific, we suggest
-that this data be stored outside the TOM and accessed through environment variables.
+.. note:: For sensitive data that is used by the TOM itself and is not user-specific,
+    we suggest that this data be stored outside the TOM and accessed through
+    environment variables.
 
 Creating and accessing an encrypted Model field
 -----------------------------------------------

--- a/docs/customization/encrypted_model_fields.rst
+++ b/docs/customization/encrypted_model_fields.rst
@@ -17,8 +17,8 @@ utility functions to help encrypt user-specific sensitive data and access it whe
 NOTE: For sensitive data that is used by the TOM itself and is not user-specific, we suggest
 that this data be stored outside the TOM and accessed through environment variables.
 
-Quick Start
------------
+Creating and accessing an encrypted Model field
+-----------------------------------------------
 
 Creating an encrypted Model field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/customization/encrypted_model_fields.rst
+++ b/docs/customization/encrypted_model_fields.rst
@@ -71,7 +71,9 @@ methods provided in ``tom_common.session_utils.py``:
     set_encrypted_field(user, profile, 'api_key', new_api_key)
 
 Note here that the User instance (``user``) is used to access the ``EncryptableModelMixin``
-subclass and it's encrypted data. (This is user-specific sensitive data).
+subclass and it's encrypted data. The ``user`` property of the encrypted field-containing
+Model subclass (``MyAppModel`` in our example) is provided by the ``EncryptableModelMixin``.
+As such, the model *should not define a* ``user`` *property of it's own*.
 
 Some Explainations
 -------------------

--- a/docs/customization/encrypted_model_fields.rst
+++ b/docs/customization/encrypted_model_fields.rst
@@ -63,7 +63,7 @@ methods provided in ``tom_common.session_utils.py``:
     from tom_common.session_utils import get_encrypted_field, set_encrypted_field
     from tom_app_example.models import MyAppModel
     
-    profile: MyAppModel = user.myappmodel  # encrypted field-containing Model instance
+    profile: MyAppModel = user.myappmodel  # Model instance containing an encrypted field
     
     # getter example
     decrypted_api_key: str = get_encrypted_field(user, profile, 'api_key')

--- a/docs/customization/encrypted_model_fields.rst
+++ b/docs/customization/encrypted_model_fields.rst
@@ -8,7 +8,7 @@ Examples of user-specific sensitive
 data include a password or API key for an external service that your TOM uses.
 For example, TOMToolkit Facility modules can use the mechanism described here to store,
 encrypted, user-specific credentials in a user profile model. Examples include
-the ``tom_eso`` and (soon) the ``tom_swift`` facility modules.
+the ``tom_eso`` and the ``tom_swift`` facility modules.
 
 As we explain below, TOMToolkit provides a *_mix-in_* class, a *property descriptor*, and
 utility functions to help encrypt user-specific sensitive data and access it when it's needed.
@@ -78,14 +78,14 @@ As such, the model *should not define a* ``user`` *property of its own*.
 Some Explanations
 -----------------
 
-EncryptableModelMixin
+EncryptableModelMixin (`source <https://github.com/TOMToolkit/tom_base/blob/069024f954e5540c1441c5186378de538f7d606f/tom_common/models.py#L100>`__)
 ~~~~~~~~~~~~~~~~~~~~~
 The User's data is encrypted using (among other things) their password (i.e the
 password they use to login to your TOM). When the User changes their password,
 their encrypted data re-encrypted accordingly. The ``EncryptableModelMixin`` adds
 method for this to your otherwise normal Django model.
 
-EncryptedProperty
+EncryptedProperty (`source <https://github.com/TOMToolkit/tom_base/blob/069024f954e5540c1441c5186378de538f7d606f/tom_common/models.py#L39>`__)
 ~~~~~~~~~~~~~~~~~
 A *property descriptor* implements the Python descriptor protocol (``__get__``,
 ``__set__``, etc). The ``EncryptedProperty`` property descriptor handles the details
@@ -93,7 +93,7 @@ of decrypting the encrypted ``BinaryField`` on its way out of the database and
 encrypting it on the way in. It is invoked when the property is accessed
 (e.g. ``model_instance.api_key``).
 
-Session Utils
+Session Utils (`example <https://github.com/TOMToolkit/tom_eso/blob/b74fe3b951ead6f6f332594724731d036944da47/tom_eso/eso.py#L209>`__)
 ~~~~~~~~~~~~~
 The ``get_encrypted_field`` and ``set_encrypted_field`` functions implement
 boilerplate code for creating and destroying the cipher used to encrypt and

--- a/docs/customization/encrypted_model_fields.rst
+++ b/docs/customization/encrypted_model_fields.rst
@@ -11,7 +11,7 @@ encrypted, user-specific credentials in a user profile model. Examples include t
 `tom_eso <https://github.com/TOMToolkit/tom_eso>`__ and the
 `tom_swift <https://github.com/TOMToolkit/tom_swift>`__ facility modules.
 
-As we explain below, TOMToolkit provides a *_mix-in_* class, a *property descriptor*, and
+As we explain below, TOMToolkit provides a *mix-in* class, a *property descriptor*, and
 utility functions to help encrypt user-specific sensitive data and access it when it's needed.
 
 .. note:: For sensitive data that is used by the TOM itself and is not user-specific,

--- a/docs/customization/encrypted_model_fields.rst
+++ b/docs/customization/encrypted_model_fields.rst
@@ -73,8 +73,8 @@ methods provided in ``tom_common.session_utils.py``:
     set_encrypted_field(user, profile, 'api_key', new_api_key)
 
 Note here that the User instance (``user``) is used to access the ``EncryptableModelMixin``
-subclass and its encrypted data. The ``user`` property of the encrypted field-containing
-Model subclass (``MyAppModel`` in our example) is provided by the ``EncryptableModelMixin``.
+subclass and its encrypted data. The ``user`` property of the Model subclass containing the
+encrypted field (``MyAppModel`` in our example) is provided by the ``EncryptableModelMixin``.
 As such, the model *should not define a* ``user`` *property of its own*.
 
 Some Explanations

--- a/docs/customization/encrypted_model_fields.rst
+++ b/docs/customization/encrypted_model_fields.rst
@@ -1,0 +1,103 @@
+Encrypted Model Fields
+======================
+
+If your ``custom_code`` or reusable app contains a Model field storing user-specific
+sensitive data, then you may want to encrypt that data.
+
+Examples of user-specific sensitive
+data include a password or API key for an external service that your TOM uses.
+For example, TOMToolkit Facility modules can use the mechanim described here to store,
+encrypted, user-specific credentials in a user profile model. Examples include
+the ``tom_eso`` and (soon) the ``tom_swift`` facility modules.
+
+As we explain below, TOMToolkit provides a *_mix-in_* class, a *property descriptor*, and
+utility functions to help encrypt user-specific sensitive data and access it when it's needed.
+
+NOTE: For sensitive data that is used by the TOM itself and is not user-specific, we suggest
+that this data be stored outside the TOM and accessed through environment variables.
+
+Quick Start
+-----------
+
+Creating an encryted Model field
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your Model has a field that should be encrypted, follow these steps:
+
+1. Import the mix-in class and property descriptor in your ``models.py``:
+
+.. code-block:: python
+
+    from tom_common.models import EncryptableModelMixin, EncryptedProperty
+
+2. Make your Model subclass a subclass of ``EcryptableModelMixin``. For example:
+
+.. code-block:: python
+
+    class MyAppModel(EncryptableModelMixin, models.Model):
+        ...
+
+This gives your model access to a set of methods that will manage the encyption and
+decyption of your data into and out of the ``BinaryField`` that stores the encrypted data.
+
+3. Add the ``BinaryField`` that will store the encrypted data and the property descriptor
+through which the ``BinaryField`` will be accessed.
+
+.. code-block:: python
+
+    _ciphertext_api_key = BinaryField(null=True, blank=True)  # encrypted data field (private)
+    api_key = EncryptedProperty('_ciphertext_api_key')  # descriptor that provides access (public)
+
+By convention name of the ``BinaryField`` field should begin with and underscore
+(``_ciphertext_api_key`` in our example) because is it private to the Model class.
+
+Accessing encrytped data
+~~~~~~~~~~~~~~~~~~~~~~~~
+The following example shows how to get and set an encrypted field using the utility
+methods provided in ``tom_common.session_utils.py``:
+
+.. code-block:: python
+
+    from tom_common.session_utils import get_encrypted_field, set_encrypted_field
+    from tom_app_example.models import MyAppModel
+    
+    profile: MyAppModel = user.myappmodel  # encrypted field-containing Model instance
+    
+    # getter example
+    decrypted_api_key: str = get_encrypted_field(user, profile, 'api_key')
+    
+    # setter example
+    new_api_key: str = 'something_secret'
+    set_encrypted_field(user, profile, 'api_key', new_api_key)
+
+Note here that the User instance (``user``) is used to access the ``EncryptableModelMixin``
+subclass and it's encrypted data. (This is user-specific sensitive data).
+
+Some Explainations
+-------------------
+
+EncryptableModelMixin
+~~~~~~~~~~~~~~~~~~~~~
+The User's data is encrypted using (among other things) their password (i.e the
+password they use to login to your TOM). When the User changes their password,
+their encrypted data reencrtyped accordingly. The ``EncryptableModelMixin`` adds
+method for this to your otherwise normal Django model.
+
+EncryptedProperty
+~~~~~~~~~~~~~~~~~
+A *property descriptor* implements the Python descriptor protocol (``__get__``,
+``__set__``, etc). The ``EncryptedProperty`` property descriptor handles the details
+of decrypting the encrypted ``BinaryField`` on it's way out of the database and
+encrypting it on the way in. It is invoked when the propetry is accessed
+(e.g. ``model_instance.api_key``).
+
+Session Utils
+~~~~~~~~~~~~~
+The ``get_encrypted_field`` and ``set_encrypted_field`` functions implement
+boilerplate code for creating and destroying the cipher used to encrypt and
+decypt the ``BinaryField``. *These methods must always be used to access any
+encrypted field*.
+
+
+The rest of the details are in the source code. If reading source code isn't your thing,
+please do feel free to get in touch and we'll be happy to answer any questions you may have.

--- a/docs/customization/index.rst
+++ b/docs/customization/index.rst
@@ -10,6 +10,7 @@ Customization
   customize_template_tags
   testing_toms
   widgets
+  encrypted_model_fields
 
 
 Start here to learn how to customize the look and feel of your TOM or add new functionality.
@@ -26,3 +27,6 @@ the data you need.
 :doc:`Testing TOMs <testing_toms>` - Learn how to test your TOM's functionality.
 
 :doc:`TOM Widgets <widgets>` - Include these widgets in your custom templates.
+
+:doc:`Encrypting Data in a Model Field <encrypted_model_fields>` - Learn how to encrypt sensitive data like
+passwords and API keys in your TOMToolkit app.


### PR DESCRIPTION
- fixes #1242 

To create html previews locally for this branch:
  1. pip install sphinx sphinx-rtd-theme sphinx-panels sphinx_copybutton recommonmark
  2. cd tom_base/docs
  3. make html
  4. point your browser to file:///path/to/tom_base/docs/_build/html/index.html

(that's all in the DevOps runbook but provided here for convenience)
