### PR TITLE
Broker query list and run views should require authentication.

### DIFF
--- a/tom_alerts/views.py
+++ b/tom_alerts/views.py
@@ -154,7 +154,7 @@ class BrokerQueryFilter(FilterSet):
         fields = ['broker', 'name']
 
 
-class BrokerQueryListView(FilterView):
+class BrokerQueryListView(LoginRequiredMixin, FilterView):
     """
     View that displays all saved ``BrokerQuery`` objects.
     """
@@ -182,7 +182,7 @@ class BrokerQueryDeleteView(LoginRequiredMixin, DeleteView):
     success_url = reverse_lazy('tom_alerts:list')
 
 
-class RunQueryView(TemplateView):
+class RunQueryView(LoginRequiredMixin, TemplateView):
     """
     View that handles the running of a specific ``BrokerQuery``.
     """


### PR DESCRIPTION
Prevents the bots from accessing the alert list/running alerts. 

There are 2 follow-up improvements that could be made:

1. Make the query run view a POST request. This is more correct. But requires a bit of refactoring as the error views rely on the GET machinery to exist.
2. Make ALL views LoginRequired by default (now the default in Django) and explicitly allow non-authenticated views. This is a much larger change that has the potential to be disruptive if any existing TOMS rely on non-authenticated access to views.

Fixes #855 