### PR TITLE
skip migration for empty DB

### DIFF
--- a/tom_targets/migrations/0025_auto_20250206_2017.py
+++ b/tom_targets/migrations/0025_auto_20250206_2017.py
@@ -12,8 +12,8 @@ def get_target_model():
 
 def remove_public_group(apps, schema_editor):
     target_app, target_model = get_target_model()
-    # The following methods try to reference apps outside tom_targets. When trying to run this migration for the first 
-    # time on an empty database, these outside apps may not be installed yet, unless there is a migration from these 
+    # The following methods try to reference apps outside tom_targets. When trying to run this migration for the first
+    # time on an empty database, these outside apps may not be installed yet, unless there is a migration from these
     # apps in the dependencies list. Since the purpose of this data migration is to transfer the previous permission
     # system to a newer one, this migration can be skipped for an empty database.
     # See https://docs.djangoproject.com/en/dev/topics/migrations/#accessing-models-from-other-apps


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/topics/migrations/#accessing-models-from-other-apps

I couldn't track down exactly why this error happened for some TOMs and not others. All of my research suggested that the order apps are installed isn't consistent across projects with a lot of "this sometimes happens" or "You may see this error". This appears to only be an issue when building an empty DB. If migrations from those apps have already been made there is no issue. This is why many people seem to run into this issue for the first time during testing.

In this case, the guaranteed way to avoid this is to include a migration from the app in question in the list of migration dependencies. This doesn't really work here because we don't actually know what app people are going to use for their custom target model so we can't depend on it. Instead, since there is no data to migrate if it's an empty DB, I've just wrapped the problem pieces in a try/except and effectively do nothing for this migration in that case.