### PR TITLE
Add a QueryServiceError for dataservices module

### DIFF
--- a/tom_dataservices/dataservices.py
+++ b/tom_dataservices/dataservices.py
@@ -64,6 +64,13 @@ class NotConfiguredError(Exception):
     pass
 
 
+class QueryServiceError(Exception):
+    """
+    Represents a higher level error when an underlying service or client library fails.
+    """
+    pass
+
+
 class BaseDataService(ABC):
     """
     Base class for all Data Services. Data Services are classes that are responsible for querying external services

--- a/tom_dataservices/views.py
+++ b/tom_dataservices/views.py
@@ -18,6 +18,7 @@ from urllib.parse import urlencode
 
 from tom_dataservices.models import DataServiceQuery
 from tom_dataservices.dataservices import get_data_service_classes, get_data_service_class, NotConfiguredError
+from tom_dataservices.dataservices import QueryServiceError
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +179,9 @@ class RunQueryView(TemplateView):
         except NotConfiguredError as e:
             results = iter(())
             query_feedback += f"Configuration Error. Please contact your TOM Administrator: </br>{e}</br>"
+        except QueryServiceError as e:
+            results = iter(())
+            query_feedback += f"There was an error with the underlying query service: </br>{e}</br>"
 
         # create context for template
         context['query'] = query


### PR DESCRIPTION
This is needed because the underlying query might not be using HTTP directly. Alerce has a client library, so the Alerce Dataservice is using that, which raises it's own custom exceptions.