### PR TITLE
Add back crispy field tag for rendering form

### DIFF
--- a/tom_dataservices/forms.py
+++ b/tom_dataservices/forms.py
@@ -1,3 +1,4 @@
+from crispy_forms.layout import Layout
 from django import forms
 from crispy_forms.helper import FormHelper
 
@@ -24,7 +25,12 @@ class BaseQueryForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_tag = False
-        # self.helper['query_save'].wrap(Field, type='hidden')
+        self.helper.layout = self.get_layout()
+
+    def get_layout(self):
+        exclude = ["query_save", "query_name"]
+        field_keys = [f for f in self.fields.keys() if f not in exclude]
+        return Layout(*field_keys)
 
     def save(self, query_id=None):
         """

--- a/tom_dataservices/templates/tom_dataservices/query_form.html
+++ b/tom_dataservices/templates/tom_dataservices/query_form.html
@@ -25,7 +25,7 @@
         {% if advanced_form %}
             {% include advanced_form %}
         {% else %}
-            {% bootstrap_form form exclude='query_name,query_save' %}
+            {% crispy form %}
         {% endif %}
     {% endif %}
 


### PR DESCRIPTION
Requires us to implement a default for get_layout which excludes the forms related to saving the query.