### PR TITLE
Validate MJD for non-sidereal fields

### DIFF
--- a/tom_targets/forms.py
+++ b/tom_targets/forms.py
@@ -1,3 +1,4 @@
+from tom_targets.validators import validate_mjd
 import datetime
 
 from crispy_forms.layout import Layout, Div
@@ -142,6 +143,16 @@ class NonSiderealTargetCreateForm(TargetForm):
         super().__init__(*args, **kwargs)
         for field in REQUIRED_NON_SIDEREAL_FIELDS:
             self.fields[field].required = True
+
+    def clean_epoch_of_perihelion(self):
+        if value := self.cleaned_data.get('epoch_of_perihelion'):
+            validate_mjd(value)
+        return value
+
+    def clean_epoch_of_elements(self):
+        if value := self.cleaned_data.get('epoch_of_elements'):
+            validate_mjd(value)
+        return value
 
     def clean(self):
         """

--- a/tom_targets/tests/tests.py
+++ b/tom_targets/tests/tests.py
@@ -389,6 +389,36 @@ class TestTargetCreate(TestCase):
         self.assertEqual(te.typed_value('number'), 1984.0)
         self.assertIsNone(te.typed_value('datetime'))
 
+    def test_non_sidereal_validate_mjd(self):
+        base_data = {
+            'name': 'nonsidereal_target',
+            'identifier': 'nonsidereal_identifier',
+            'type': Target.NON_SIDEREAL,
+            'scheme': 'JPL_MAJOR_PLANET',
+            'permissions': 'PUBLIC',
+            'epoch_of_elements': 1_000_000,
+            'lng_asc_node': 100,
+            'arg_of_perihelion': 100,
+            'eccentricity': 100,
+            'mean_anomaly': 100,
+            'inclination': 100,
+            'semimajor_axis': 100,
+            'targetextra_set-TOTAL_FORMS': 1,
+            'targetextra_set-INITIAL_FORMS': 0,
+            'targetextra_set-MIN_NUM_FORMS': 0,
+            'targetextra_set-MAX_NUM_FORMS': 1000,
+            'targetextra_set-0-key': '',
+            'targetextra_set-0-value': '',
+            'aliases-TOTAL_FORMS': 1,
+            'aliases-INITIAL_FORMS': 0,
+            'aliases-MIN_NUM_FORMS': 0,
+            'aliases-MAX_NUM_FORMS': 1000,
+        }
+        create_url = reverse('targets:create') + '?type=NON_SIDEREAL'
+        response = self.client.post(create_url, data=base_data, follow=True)
+        errors = response.context['form'].errors['epoch_of_elements']
+        self.assertIn('Value must be in MJD', errors[0])
+
     def test_non_sidereal_required_fields(self):
         base_data = {
             'name': 'nonsidereal_target',

--- a/tom_targets/validators.py
+++ b/tom_targets/validators.py
@@ -1,4 +1,5 @@
 from rest_framework.serializers import ValidationError
+from django.forms import ValidationError as FormValidationError
 
 
 class RequiredFieldsTogetherValidator(object):
@@ -21,3 +22,8 @@ class RequiredFieldsTogetherValidator(object):
 
         if missing_fields:
             raise ValidationError(f'The following fields are required for {self.type_value} targets: {missing_fields}')
+
+
+def validate_mjd(value):
+    if not (0 <= value <= 100000.0):
+        raise FormValidationError("Value must be in MJD between 0 and 100000")


### PR DESCRIPTION
Validates that epoch_of_elements and epoch_of_perihelion use valid MJD values (previously would accept values in JD).