### PR TITLE
use observation_id in update_observation_status

### DIFF
--- a/tom_observations/models.py
+++ b/tom_observations/models.py
@@ -82,7 +82,7 @@ class ObservationRecord(models.Model):
 
     def update_status(self):
         facility = get_service_class(self.facility)
-        facility().update_observation_status(self.id)
+        facility().update_observation_status(self.observation_id)
 
     def save_data(self):
         facility = get_service_class(self.facility)


### PR DESCRIPTION
`facility.update_obseravation_status()` should take the `observation_record.observation_id` (the ID at the observatory) instead of the `observation_record.id` (the internal primary key).