### PR TITLE
runbrokerquery management command should not run forever

### DIFF
--- a/tom_alerts/management/commands/runbrokerquery.py
+++ b/tom_alerts/management/commands/runbrokerquery.py
@@ -3,7 +3,6 @@ from django.core.exceptions import ValidationError
 
 from tom_alerts.models import BrokerQuery
 from tom_alerts.alerts import get_service_class
-from time import sleep
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
This changes the `manage.py runbrokerquery` command from a `while` loop to a `for` loop, so that it does not continue running forever without re-querying the broker. It should likely be run on a cronjob.