### PR TITLE
fix: Implement facility status for LCORedirectFacility

### DIFF
--- a/tom_observations/facilities/lco_redirect.py
+++ b/tom_observations/facilities/lco_redirect.py
@@ -122,3 +122,6 @@ class LCORedirectFacility(BaseRedirectObservationFacility):
             observation_group.observation_records.add(obs_record)
 
         return observation_group
+
+    def get_facility_status(self):
+        return self.lco_facility.get_facility_status()


### PR DESCRIPTION
When spinning up a new TOM with `LCORedirectFacility`, the telescope facility status page (`/observations/status/`) returns an empty result for that facility.

This occurs because `BaseObservationFacility.get_facility_status()` defaults to returning an empty `dict`, and `LCORedirectFacility` does not override or delegate this method.