### PR TITLE
show User their DRF API token

### DIFF
--- a/tom_common/templates/tom_common/partials/user_data.html
+++ b/tom_common/templates/tom_common/partials/user_data.html
@@ -24,6 +24,10 @@
                 <dd class="col-sm-6">{{ value }}</dd>
             {% endif %}
         {% endfor %}
+        {% if drf_api_token %}
+            <dt class="col-sm-6" >API Token</dt>
+            <dd class="col-sm-6">{{ drf_api_token }}</dd>
+        {% endif %}
     </dl>
   </div>
 </div>

--- a/tom_common/templatetags/user_extras.py
+++ b/tom_common/templatetags/user_extras.py
@@ -75,12 +75,20 @@ def user_data(user):
     exclude_fields = ['password', 'last_login', 'id', 'is_active', 'user']
     user_dict = model_to_dict(user, exclude=exclude_fields)
     profile_dict = model_to_dict(user.profile, exclude=exclude_fields)
-    return {
+
+    # Get the auth_token from the Python descriptor attached (at runtime)
+    # to the User model by Django as a reverse relation (the related_name)
+    # to the rest_framework.authtoken.models.Token
+    drf_api_token = getattr(user, 'auth_token', None)
+
+    user_data = {
         'user': user,
         'profile': user.profile,
         'user_data': user_dict,
         'profile_data': profile_dict,
+        'drf_api_token': drf_api_token,
     }
+    return user_data
 
 
 @register.inclusion_tag('tom_common/partials/app_profiles.html', takes_context=True)


### PR DESCRIPTION
* in `tom_common/templatetags/user_extras.py`: in the `user_data` inclusion_tag, add the DRF `auth_token` (as `drf_api_token`) to the context sent to the User's Profile card

* In the Profile Card (`tom_common/templates/tom_common/partials/user_data.html`), template, check for the `drf_api_token` in the context and, if it's there, display it.

closes #1468 