### PR TITLE
1473 reset drf api token feature

### DIFF
--- a/tom_common/templates/tom_common/create_user.html
+++ b/tom_common/templates/tom_common/create_user.html
@@ -24,4 +24,7 @@
   </button>
 {% endbuttons %}
 </form>
+{% if object %}
+  {% include 'tom_common/partials/api_token.html' %}
+{% endif %}
 {% endblock %}

--- a/tom_common/templates/tom_common/partials/api_token.html
+++ b/tom_common/templates/tom_common/partials/api_token.html
@@ -1,0 +1,17 @@
+<div id="api-token-container" class="mt-3">
+  <h5>API Token</h5>
+  {% if drf_api_token %}
+    <code>{{ drf_api_token }}</code>
+  {% else %}
+    <span class="text-muted">No token generated.</span>
+  {% endif %}
+  <form hx-post="{% url 'regenerate-api-token' pk=user_pk %}"
+        hx-target="#api-token-container"
+        hx-swap="outerHTML"
+        hx-confirm="Regenerate API token? Your current API token will stop working immediately.">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-warning btn-sm mt-2">
+      Regenerate API Token
+    </button>
+  </form>
+</div>

--- a/tom_common/tests.py
+++ b/tom_common/tests.py
@@ -232,6 +232,66 @@ class TestUserProfile(TestCase):
         self.assertEqual(user.profile.affiliation, 'Test University')
 
 
+class TestRegenerateAPIToken(TestCase):
+    """Tests for the RegenerateAPITokenView."""
+
+    def setUp(self):
+        self.admin = User.objects.create_superuser(username='admin', password='admin', email='admin@example.com')
+        self.user = User.objects.create_user(username='testuser', password='testpass', email='user@example.com')
+        # Tokens are auto-created by the post_save signal in tom_common.signals
+
+    def test_regenerate_own_token(self):
+        """A logged-in user can regenerate their own API token."""
+        self.client.force_login(self.user)
+        old_token_key = self.user.auth_token.key
+
+        # token regeneration happens here
+        response = self.client.post(reverse('regenerate-api-token', kwargs={'pk': self.user.pk}))
+
+        self.user.refresh_from_db()
+        new_token_key = self.user.auth_token.key
+
+        self.assertNotEqual(old_token_key, new_token_key)
+        self.assertRedirects(response, reverse('user-update', kwargs={'pk': self.user.pk}))
+
+    def test_non_superuser_cannot_regenerate_other_user_token(self):
+        """A non-superuser cannot regenerate another user's token."""
+        self.client.force_login(self.user)
+        old_token_key = self.admin.auth_token.key
+
+        response = self.client.post(reverse('regenerate-api-token', kwargs={'pk': self.admin.pk}))
+
+        # Should redirect to the requesting user's own update page
+        self.assertRedirects(response, reverse('user-update', kwargs={'pk': self.user.pk}))
+        # Admin's token should be unchanged
+        self.admin.refresh_from_db()
+        self.assertEqual(old_token_key, self.admin.auth_token.key)
+
+    def test_superuser_can_regenerate_other_user_token(self):
+        """A superuser can regenerate another user's token."""
+        self.client.force_login(self.admin)
+        old_token_key = self.user.auth_token.key
+
+        response = self.client.post(reverse('regenerate-api-token', kwargs={'pk': self.user.pk}))
+
+        self.user.refresh_from_db()
+        new_token_key = self.user.auth_token.key
+        self.assertNotEqual(old_token_key, new_token_key)
+        self.assertRedirects(response, reverse('user-update', kwargs={'pk': self.user.pk}))
+
+    def test_get_request_returns_405(self):
+        """GET requests should return 405 Method Not Allowed."""
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('regenerate-api-token', kwargs={'pk': self.user.pk}))
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_unauthenticated_redirects_to_login(self):
+        """Unauthenticated requests should redirect to login."""
+        response = self.client.post(reverse('regenerate-api-token', kwargs={'pk': self.user.pk}))
+        self.assertRedirects(response, reverse('login') + '?next=' +
+                             reverse('regenerate-api-token', kwargs={'pk': self.user.pk}))
+
+
 class TestAuthScheme(TestCase):
     @override_settings(AUTH_STRATEGY='LOCKED')
     def test_user_cannot_access_view(self):

--- a/tom_common/urls.py
+++ b/tom_common/urls.py
@@ -27,6 +27,7 @@ from tom_base import __version__
 from tom_common.api_views import GroupViewSet
 from tom_common.views import UserListView, UserPasswordChangeView, UserCreateView, UserDeleteView, UserUpdateView
 from tom_common.views import CommentDeleteView, GroupCreateView, GroupUpdateView, GroupDeleteView, UserProfileView
+from tom_common.views import RegenerateAPITokenView
 from tom_common.views import robots_txt
 
 from .api_router import collect_api_urls, SharedAPIRootRouter  # DRF routers are setup in each INSTALL_APPS url.py
@@ -58,6 +59,7 @@ urlpatterns += [
     path('users/create/', UserCreateView.as_view(), name='user-create'),
     path('users/<int:pk>/delete/', UserDeleteView.as_view(), name='user-delete'),
     path('users/<int:pk>/update/', UserUpdateView.as_view(), name='user-update'),
+    path('users/<int:pk>/regenerate-token/', RegenerateAPITokenView.as_view(), name='regenerate-api-token'),
     path('users/profile/', UserProfileView.as_view(), name='user-profile'),
     path('groups/create/', GroupCreateView.as_view(), name='group-create'),
     path('groups/<int:pk>/update/', GroupUpdateView.as_view(), name='group-update'),

--- a/tom_common/views.py
+++ b/tom_common/views.py
@@ -1,4 +1,5 @@
 import logging
+from django.views import View
 from django.views.generic import TemplateView
 from django.views.generic.edit import FormView, DeleteView
 from django.views.generic.edit import UpdateView, CreateView
@@ -10,8 +11,11 @@ from django.views.decorators.http import require_GET
 from django.urls import reverse_lazy
 from django.contrib import messages
 from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
+from django.template.loader import render_to_string
 from django.contrib.auth import update_session_auth_hash
+
+from rest_framework.authtoken.models import Token
 
 from tom_common.models import UserSession
 from tom_common.forms import ChangeUserPasswordForm, CustomUserCreationForm, GroupForm
@@ -81,6 +85,54 @@ class UserDeleteView(LoginRequiredMixin, DeleteView):
             return redirect('user-delete', self.request.user.id)
         else:
             return super().dispatch(*args, **kwargs)
+
+
+class RegenerateAPITokenView(LoginRequiredMixin, View):
+    """View that handles regeneration of a User's DRF API token. Requires login.
+
+    Deletes the existing token (if any) and creates a new one. For HTMX requests,
+    returns the api_token partial with the new token. For non-HTMX requests,
+    redirects to the user update page with a success message.
+    """
+    # this is the partial template to render the API token
+    partial_template_name = 'tom_common/partials/api_token.html'
+
+    def dispatch(self, *args, **kwargs):
+        """Ensure non-superusers can only regenerate their own token.
+
+        Checks authentication first (via LoginRequiredMixin), then checks
+        that non-superusers are only operating on their own token.
+        """
+        # the User must be authenticated
+        if not self.request.user.is_authenticated:
+            return self.handle_no_permission()
+
+        # don't let a non-super-user regenerate someone else's API Token,
+        # instead, redirect them to their own user-update view.
+        if not self.request.user.is_superuser and self.request.user.id != int(self.kwargs['pk']):
+            return redirect('user-update', pk=self.request.user.id)
+        return super().dispatch(*args, **kwargs)
+
+    def post(self, request, pk: int) -> HttpResponse:
+        target_user = get_object_or_404(User, pk=pk)
+
+        # Delete existing token (safe even if none exists) and create a new one
+        Token.objects.filter(user=target_user).delete()
+        new_token = Token.objects.create(user=target_user)
+
+        # handle HTMX requests here
+        if request.htmx:
+            # Return just the partial for in-place replacement (avoid full page reload)
+            html = render_to_string(
+                self.partial_template_name,
+                {'drf_api_token': new_token, 'user_pk': target_user.pk},
+                request=request,
+            )
+            return HttpResponse(html)
+
+        # Non-HTMX fallback: redirect with a success message
+        messages.success(request, 'API token regenerated.')
+        return redirect('user-update', pk=target_user.pk)
 
 
 class UserProfileView(LoginRequiredMixin, TemplateView):
@@ -194,9 +246,19 @@ class UserUpdateView(LoginRequiredMixin, UpdateView):
             return reverse_lazy('user-update', kwargs={'pk': self.request.user.id})
 
     def get_context_data(self, **kwargs):
-        """Add current user to the context for all templates."""
+        """Add current user and API token to the context for all templates."""
         context = super().get_context_data(**kwargs)
+
+        # this is the User doing the updating. (could be super-user)
         context['current_user'] = self.request.user
+
+        # this is the User being updated (usually the same as the requesting User,
+        # but not if a super-user is updating a different User).
+        user_being_updated = self.object
+
+        # add context required to Regenerate the user's DRF API token
+        context['drf_api_token'] = getattr(user_being_updated, 'auth_token', None)
+        context['user_pk'] = user_being_updated.pk
         return context
 
     def get_form(self, form_class=None):


### PR DESCRIPTION
This takes standard approach (same as HERMES and Observation Portal):
- creates a new `RegenerateAPITokenView` and it's urlpattern
- adds DRF API token context to the UpdateUserView context
- adds a template partial for HTMX redisplay of regenerated DRF API token
- adds that template partial to user_create.html template
- adds test for this

closes #1473 