### PR TITLE
set minimum django dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4161,4 +4161,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<3.14"
-content-hash = "47ee2d513e2e0f1f2f61b1389a237fdadd6a138ee2ca991e2fb0822f208f74e2"
+content-hash = "b33f104ac30d5968644df554d31eaa53d0b1bf644cf30de45d363a9be52fd56d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "astropy >=5.3.3,<8 ; python_version >= '3.10'",
     "astropy >=5.3.3,<6 ; python_version < '3.10'",
     "cryptography <=47",
-    "django <6",
+    "django >=5,<6",
     "djangorestframework >=3.15,<4",
     "django-bootstrap4 >3,<25",
     "beautifulsoup4 <5",


### PR DESCRIPTION
Removing Django 4.2 as a dependency due to EOL