### PR TITLE
Show indicator on sortable columns with no sort applied

### DIFF
--- a/tom_common/static/tom_common/css/main.css
+++ b/tom_common/static/tom_common/css/main.css
@@ -131,14 +131,23 @@ td, th {
 }
 
 /* add up and down sorting arrows to column headers  */
-.table-container th.asc::after {
-    content: '\0000a0\0025bc';
+.table-container th:not(.asc):not(.desc):not(:has(input))::after,
+.table-container th.asc:not(:has(input))::after,
+.table-container th.desc:not(:has(input))::after {
     float: left;
+    padding-right: 4px;
 }
 
-.table-container th.desc::after {
-    content: '\0000a0\0025b2';
-    float: left;
+.table-container th:not(.asc):not(.desc):not(:has(input))::after {
+    content: '\0021C5';
+}
+
+.table-container th.asc:not(:has(input))::after {
+    content: '\0025B2';
+}
+
+.table-container th.desc:not(:has(input))::after {
+    content: '\0025BC';
 }
 
 /* Create copy button class */
@@ -318,4 +327,3 @@ td, th {
     opacity: 1;
     transition: opacity 0.5s ease-out;
 }
-


### PR DESCRIPTION
Shows the double arrows on columns which are sortable but don't have sorting applied.
From the issue:

> We need to show which column the table is sorted by from the outset

This works already, the issue is the target table is sorted by "-created" by default and that's not actually a column in the table. I tested that it does work by changing the default sort to "-name" and the column appears with the down arrow as expected.

<img width="1155" height="362" alt="image" src="https://github.com/user-attachments/assets/0e7b33ab-8afc-44ca-908a-566a912cd27b" />

Fixes #1411 