### PR TITLE
Update documentation of plugin list and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,37 +69,12 @@ Please review our [code of conduct](CODE_OF_CONDUCT.md) for information about wh
 For development information targeted at the maintainers of the project, please see [README-dev.md](README-dev.md).
 
 ## Plugins
-
-### tom_alerts_dash
-
-The [tom_alerts_dash](https://github.com/TOMToolkit/tom_alerts_dash) plugin adds responsive ReactJS views to the
-`tom_alerts` module for supported brokers.
-
-### Antares
-
-The [tom-antares](https://github.com/TOMToolkit/tom_antares) plugin adds support
-for querying the Antares broker for targets of interest.
-
-### tom_nonsidereal_airmass
-
-The [tom_nonsidereal_airmass](https://github.com/TOMToolkit/tom_nonsidereal_airmass) plugin provides a templatetag
-that supports plotting for non-sidereal objects. The plugin is fully supported by the TOM Toolkit team; however,
-non-sidereal visibility calculations require the PyEphem library, which is minimally supported while its successor
-is in development. The library used for the TOM Toolkit sidereal visibility, astroplan, does not yet support
-non-sidereal visibility calculations.
-
-### tom-lt
-
-This module provides the ability to submit observations to the Liverpool Telescope Phase 2 system. It is in a very alpha
-state, with little error handling and minimal instrument options, but can successfully submit well-formed observation
-requests.
-
-[Github](https://github.com/TOMToolkit/tom_lt)
-
-### tom_registration
-
-The [tom_registration](https://github.com/TOMToolkit/tom_registration) plugin introduces support for two TOM registration
-flows--an open registration, and a registration that requires administrator approval.
+Our philosophy is to keep the TOM as lightweight and adaptable as possible.  
+Different TOM systems have different science goals and sometimes need 
+different functions. Rather than require users to support all 
+dependencies from all possible functions, we support a range of optional 
+plugin modules for the Toolkit.  Have a look at our [list of plugins](https://tom-toolkit.readthedocs.io/en/stable/api/plugins.html) 
+see which would benefit your science goals. 
 
 ## About the TOM Toolkit
 

--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -2,13 +2,13 @@ TOM Toolkit Plugins
 -------------------
 
 We aim to keep the TOM as lightweight and flexible as possible, and we 
-recognise that every team has their own science goals and often need 
+recognize that every team has their own science goals and often need 
 different functions.  These often come with added dependencies.  
 
 Rather than require users to support all dependencies from all possible 
 functions, we support a range of optional plugin modules for the Toolkit. 
 These range from adding the ability to interface with additional
-observatories, to providing additional plotting or data analytics functionality.
+observatories and catalogs, to providing additional plotting or data analytics functionality.
 
 ### [tom_hermes](https://github.com/TOMToolkit/tom_hermes)
 
@@ -23,13 +23,13 @@ enables users to query this service and harvest alert information.
 
 ### [tom_antares](https://github.com/TOMToolkit/tom_antares)
 
-The [tom-antares](https://github.com/TOMToolkit/tom_antares) plugin adds support
-for querying the [ANTARES](https://antares.noirlab.edu/) broker for targets of interest.
+This plugin adds support for querying the [ANTARES](https://antares.noirlab.edu/) broker for targets of interest.
 
 ### [tom_app_template](https://github.com/TOMToolkit/tom_app_template)
 
-This repository is designed to provide an example template for TOM users 
-wishing to develop their own TOM app.  
+This repository is designed to provide a starting template for TOM users 
+wishing to develop their own TOM app. This app contains all of the basic workflows, 
+directory structure, testing infrastructure, and instructions you will need to get started.
 
 ### [tom_jpl](https://github.com/TOMToolkit/tom_jpl)
 
@@ -49,8 +49,8 @@ Coverage maps.
 
 ### [tom_registration](https://github.com/TOMToolkit/tom_registration)
 
-The [tom_registration](https://github.com/TOMToolkit/tom_registration) plugin introduces support for two TOM registration
-flows--an open registration, and a registration that requires administrator approval.
+This plugin introduces support for two TOM registration
+workflows--an open registration, and a registration that requires administrator approval.
 
 ### [tom_tns](https://github.com/TOMToolkit/tom_tns)
 
@@ -65,20 +65,22 @@ alerts streams.
 
 ### [tom_demoapp](https://github.com/TOMToolkit/tom_demoapp)
 
-This TOM application is designed to demonstrate how users can develop 
-their own TOM applications and integrate them with their TOM systems. 
+This TOM application is not designed to be installed by users, but instead act 
+as a development and demonstration app for users wishing to integrate their 
+own TOM applications with the base TOM toolkit. The code itself serves as example, 
+while the [wiki](https://github.com/TOMToolkit/tom_demoapp/wiki) gives a menu of existing integration points.
 
-### [tom_nonlocalisedevents](https://github.com/TOMToolkit/tom_nonlocalizedevents)
+### [tom_nonlocalizedevents](https://github.com/TOMToolkit/tom_nonlocalizedevents)
 
-Various events in astrophysics are hard to localise, for example gravitational wave
- or neutrino detections.  This app allows the TOM to recognise that a
+Various events in astrophysics are hard to localize, for example gravitational wave
+ or neutrino detections.  This app allows the TOM to recognize that a
 given event may be associated with a number of candidates, and provides 
 custom views designed to support this workflow.
 
 ### [tom_swift](https://github.com/TOMToolkit/tom_swift)
 
-The Neil Gehrels Swift Observatory is a space telescope offering UV/Visible and 
-X-ray instrumentation and rapid response capabilities.  This plugin 
+The [Neil Gehrels Swift Observatory](https://swift.gsfc.nasa.gov/) is a space telescope offering 
+UV/Visible and X-ray instrumentation and rapid response capabilities.  This plugin 
 enables TOM users to submit requests for Target of Opportunity observations 
 with this spacecraft. 
 
@@ -100,21 +102,10 @@ This module provides the ability to submit observations to the
 state, with little error handling and minimal instrument options, but can successfully submit well-formed observation
 requests.
 
-### [dockertom](https://github.com/TOMToolkit/dockertom)
-
-This repository demonstrates how to package a TOM system in a docker container, 
-which is often required for deployment.  
-
 ### [tom-toolkit_component_lib](https://github.com/TOMToolkit/tom-toolkit-component-lib)
 
 Demonstration of how Javascript front-end components can be integrated with 
 a TOM. 
-
-### [tom_scimma](https://github.com/TOMToolkit/tom_scimma)
-
-This app enables a TOM to subscribe to the Hopskotch alert stream developed 
-by the Scalable Cyberinfrastructure to support Multi‑Messenger Astrophysics 
-([SCiMMA](https://scimma.org/)) project.
 
 ### [tom_dash](https://github.com/TOMToolkit/tom_dash)
 
@@ -128,11 +119,16 @@ TOM module to enable observations to be submitted to the
 
 ### [tom_nonsidereal_airmass](https://github.com/TOMToolkit/tom_nonsidereal_airmass)
 
-The [tom_nonsidereal_airmass](https://github.com/TOMToolkit/tom_nonsidereal_airmass) plugin provides a templatetag
+This plugin provides a templatetag
 that supports plotting for non-sidereal objects. The plugin is fully supported by the TOM Toolkit team; however,
 non-sidereal visibility calculations require the PyEphem library, which is minimally supported while its successor
 is in development. The library used for the TOM Toolkit sidereal visibility, astroplan, does not yet support
 non-sidereal visibility calculations.
+
+### [tom_publications](https://github.com/TOMToolkit/tom_publications)
+
+This application prototyped tools to enable users to output latex-formatted 
+data from their TOM system. 
 
 ### [herokutom](https://github.com/TOMToolkit/herokutom)
 
@@ -147,11 +143,17 @@ base Toolkit.
 
 ### [tom_alerts_dash](https://github.com/TOMToolkit/tom_alerts_dash)
 
-The [tom_alerts_dash](https://github.com/TOMToolkit/tom_alerts_dash) plugin adds responsive ReactJS views to the
-`tom_alerts` module for supported brokers.  This module has been superceded 
+This plugin adds responsive ReactJS views to the
+`tom_alerts` module for supported brokers.  The `tom_alerts` module has been superseded 
 by tom_dataservices in v3.0.0.  
 
-### [tom_publications](https://github.com/TOMToolkit/tom_publications)
+### [dockertom](https://github.com/TOMToolkit/dockertom)
 
-This application prototyped tools to enable users to output latex-formatted 
-data from their TOM system.  
+This repository demonstrates how to package a TOM system in a docker container, 
+which is often required for deployment.  
+
+### [tom_scimma](https://github.com/TOMToolkit/tom_scimma)
+
+This app enables a TOM to subscribe to the Hopskotch alert stream developed 
+by the Scalable Cyberinfrastructure to support Multi‑Messenger Astrophysics 
+([SCiMMA](https://scimma.org/)) project.

--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -1,67 +1,157 @@
-Plugins
----
+TOM Toolkit Plugins
+-------------------
 
-### TOM Toolkit Plugins
+We aim to keep the TOM as lightweight and flexible as possible, and we 
+recognise that every team has their own science goals and often need 
+different functions.  These often come with added dependencies.  
 
-Additional functionality can be added to the TOM Toolkit in the form of plugins.
-These may range from adding the ability to interface with additional
+Rather than require users to support all dependencies from all possible 
+functions, we support a range of optional plugin modules for the Toolkit. 
+These range from adding the ability to interface with additional
 observatories, to providing additional plotting or data analytics functionality.
 
-### tom-alerts-dash
+### [tom_hermes](https://github.com/TOMToolkit/tom_hermes)
 
-This module supplements the tom_alerts module with Plotly Dash support for more responsive broker views.
+The [Hermes](https://hermes.lco.global) service provides a archive of 
+astronomical alerts.  This plugin allows TOM users to query Hermes and share
+data with the service.  
 
-[Github](https://github.com/TOMToolkit/tom_alerts_dash)
+### [tom_fink](https://github.com/TOMToolkit/tom_fink)
 
-[Installation Instructions](https://github.com/TOMToolkit/tom_alerts_dash#installation)
+[Fink](https://fink-broker.org/) is an alert broker service.  This plugin 
+enables users to query this service and harvest alert information. 
 
-### tom-antares
-This module provides the ability to query and/or listen to Antares alert streams
-from within a TOM.
+### [tom_antares](https://github.com/TOMToolkit/tom_antares)
 
-[Github](https://github.com/TOMToolkit/tom_antares)
+The [tom-antares](https://github.com/TOMToolkit/tom_antares) plugin adds support
+for querying the [ANTARES](https://antares.noirlab.edu/) broker for targets of interest.
 
-[Installation Instructions](https://github.com/TOMToolkit/tom_antares)
+### [tom_app_template](https://github.com/TOMToolkit/tom_app_template)
 
-#### Compatibility Notes
+This repository is designed to provide an example template for TOM users 
+wishing to develop their own TOM app.  
 
-If you're on Mac OS, it should be noted that the Antares client library has a dependency
-that only supports Mac OS 10.13 or later. If you try to run `./manage.py migrate` on an
-earlier version, you may see an error.
+### [tom_jpl](https://github.com/TOMToolkit/tom_jpl)
 
-### tom-nonsidereal-airmass
+The Jet Propulsion Laboratory provides a number of services supporting 
+Solar System science.  This plugin provides a TOM interface to JPL's 
+[SCOUT](https://cneos.jpl.nasa.gov/scout/intro.html) service.  
 
-This module provides a templatetag supporting visibility plots for non-sidereal targets. This plugin is fully
-supported by the TOM Toolkit team; however, non-sidereal visibility calculations require the PyEphem library, which is
-minimally supported while its successor is in development. The library used for the TOM Toolkit sidereal visibility,
-`astroplan`, does not yet support non-sidereal visibility calculations.
+### [tom_eso](https://github.com/TOMToolkit/tom_eso)
 
-[Github](https://github.com/TOMToolkit/tom_nonsidereal_airmass)
+This plugin enables users to compose and submit observation requests to 
+telescopes at the [European Southern Observatory](https://www.eso.org/public/). 
 
-[Installation Instructions](https://github.com/TOMToolkit/tom_nonsidereal_airmass)
+### [tom_regions](https://github.com/TOMToolkit/tom_regions)
 
-### tom-lt
+This plugin allows a TOM to store sky regions defined from Multi-Order 
+Coverage maps. 
 
-This module provides the ability to submit observations to the Liverpool Telescope Phase 2 system. It is in a very
-alpha state, with little error handling and minimal instrument options, but can successfully submit well-formed
-observation requests.
+### [tom_registration](https://github.com/TOMToolkit/tom_registration)
 
-[Github](https://github.com/TOMToolkit/tom_lt)
+The [tom_registration](https://github.com/TOMToolkit/tom_registration) plugin introduces support for two TOM registration
+flows--an open registration, and a registration that requires administrator approval.
 
-[Installation Instructions](https://github.com/TOMToolkit/tom_lt/blob/main/README.md#installation-and-setup)
+### [tom_tns](https://github.com/TOMToolkit/tom_tns)
 
-### tom-registration
+This plugin enables TOMs to report transient classifications to 
+the [Transient Name Server](https://www.wis-tns.org/).
 
-This module provides two registration flows for users to self-register--either requiring approval, or not.
+### [tom_alertstreams](https://github.com/TOMToolkit/tom_alertstreams)
 
-[Github](https://github.com/TOMToolkit/tom_registration)
+Apache Kafka is widely used in astrophysics for the dissemination of 
+alert packages.  This plugin enables a TOM system to listen to user-configured 
+alerts streams. 
 
-[Installation Instructions](https://github.com/TOMToolkit/tom_registration#installation)
+### [tom_demoapp](https://github.com/TOMToolkit/tom_demoapp)
 
-### tom-hermes
+This TOM application is designed to demonstrate how users can develop 
+their own TOM applications and integrate them with their TOM systems. 
 
-This module provides an interface to query the [Hermes alert broker](https://hermes.lco.global).
+### [tom_nonlocalisedevents](https://github.com/TOMToolkit/tom_nonlocalizedevents)
 
-[Github](https://github.com/TOMToolkit/tom_hermes)
+Various events in astrophysics are hard to localise, for example gravitational wave
+ or neutrino detections.  This app allows the TOM to recognise that a
+given event may be associated with a number of candidates, and provides 
+custom views designed to support this workflow.
 
-[Installation Instructions](https://github.com/TOMToolkit/tom_hermes#installation)
+### [tom_swift](https://github.com/TOMToolkit/tom_swift)
+
+The Neil Gehrels Swift Observatory is a space telescope offering UV/Visible and 
+X-ray instrumentation and rapid response capabilities.  This plugin 
+enables TOM users to submit requests for Target of Opportunity observations 
+with this spacecraft. 
+
+### [tom_classifications](https://github.com/TOMToolkit/tom_classifications)
+
+This app provides a number of data visualization tools for inspecting alert 
+data from multiple brokers. 
+
+### [tom_keck](https://github.com/TOMToolkit/tom_keck)
+
+Application to enable requests for Target of Opportunity observations 
+to be submitted to the [Keck Observatories](https://keckobservatory.org/).  
+Note: to be integrated with [AEONlib](https://github.com/AEONplus/AEONlib). 
+
+### [tom-lt](https://github.com/TOMToolkit/tom_lt)
+
+This module provides the ability to submit observations to the 
+[Liverpool Telescope](https://telescope.livjm.ac.uk/) Phase 2 system. It is in a very alpha
+state, with little error handling and minimal instrument options, but can successfully submit well-formed observation
+requests.
+
+### [dockertom](https://github.com/TOMToolkit/dockertom)
+
+This repository demonstrates how to package a TOM system in a docker container, 
+which is often required for deployment.  
+
+### [tom-toolkit_component_lib](https://github.com/TOMToolkit/tom-toolkit-component-lib)
+
+Demonstration of how Javascript front-end components can be integrated with 
+a TOM. 
+
+### [tom_scimma](https://github.com/TOMToolkit/tom_scimma)
+
+This app enables a TOM to subscribe to the Hopskotch alert stream developed 
+by the Scalable Cyberinfrastructure to support Multi‑Messenger Astrophysics 
+([SCiMMA](https://scimma.org/)) project.
+
+### [tom_dash](https://github.com/TOMToolkit/tom_dash)
+
+This module demonstrates how [Plotly-Dash](https://dash.plotly.com/) components can be added to a 
+TOM for data exploration and visualization. 
+
+### [tom_gemini_community](https://github.com/TOMToolkit/tom_gemini_community)
+
+TOM module to enable observations to be submitted to the 
+[Gemini Telescope's](http://www.gemini.edu/) Phase 2 system. 
+
+### [tom_nonsidereal_airmass](https://github.com/TOMToolkit/tom_nonsidereal_airmass)
+
+The [tom_nonsidereal_airmass](https://github.com/TOMToolkit/tom_nonsidereal_airmass) plugin provides a templatetag
+that supports plotting for non-sidereal objects. The plugin is fully supported by the TOM Toolkit team; however,
+non-sidereal visibility calculations require the PyEphem library, which is minimally supported while its successor
+is in development. The library used for the TOM Toolkit sidereal visibility, astroplan, does not yet support
+non-sidereal visibility calculations.
+
+### [herokutom](https://github.com/TOMToolkit/herokutom)
+
+This repository demonstrates how a TOM system can be deployed to a public 
+server using the [Heroku platform](https://www.heroku.com/).  
+
+## Archived plugins
+
+The following plugins are available but not currently supported.  In some 
+cases this is because the functionality has been integrated with the 
+base Toolkit. 
+
+### [tom_alerts_dash](https://github.com/TOMToolkit/tom_alerts_dash)
+
+The [tom_alerts_dash](https://github.com/TOMToolkit/tom_alerts_dash) plugin adds responsive ReactJS views to the
+`tom_alerts` module for supported brokers.  This module has been superceded 
+by tom_dataservices in v3.0.0.  
+
+### [tom_publications](https://github.com/TOMToolkit/tom_publications)
+
+This application prototyped tools to enable users to output latex-formatted 
+data from their TOM system.  

--- a/tom_dataservices/dataservices.py
+++ b/tom_dataservices/dataservices.py
@@ -271,7 +271,7 @@ class DataService(ABC):
         of query_reduced_data() to create_reduced_datums_from_query()
         :param target: Target object to associate with the ReducedDatum
         :param data_results: Query results from the DataService storing observation data. This should be a dictionary
-            with each key being a data_type (i.e. Photometry, Spectroscopy, etc.)
+        with each key being a data_type (i.e. Photometry, Spectroscopy, etc.)
         """
         if not data_results:
             raise MissingDataException('No Reduced Data dictionary found.')


### PR DESCRIPTION
Addresses Issue #1524 to bring the list of TOM plugin modules up to date in the ReadTheDocs documentation, and link to this page from the tom_base repo README.