### PR TITLE
1491 documentation accessing data via rest api

### DIFF
--- a/docs/managing_data/accessing_data_through_REST_API.rst
+++ b/docs/managing_data/accessing_data_through_REST_API.rst
@@ -54,7 +54,7 @@ Token Authentication
 
 Every user has a personal API token, shown as **API Token** on their
 **User Profile** page. A token suits scripts and cron jobs because it
-needs no interactive prompt. Treat it like a password.
+needs no interactive prompt. Secure your API token as you would a password.
 
 Rather than pass in a username and be prompted for a password, we'll authenticate
 by sending the token in an ``Authorization`` header:

--- a/docs/managing_data/accessing_data_through_REST_API.rst
+++ b/docs/managing_data/accessing_data_through_REST_API.rst
@@ -94,7 +94,8 @@ Pass your username and password as the ``auth`` tuple:
 Token Authentication
 *************************************************
 
-Send your API token in an ``Authorization`` header instead. No password needed:
+Send your API token in an ``Authorization`` header instead. The API token
+substitutes for the `BasicAuthentication` username and  password.
 
 .. code:: python
 

--- a/docs/managing_data/accessing_data_through_REST_API.rst
+++ b/docs/managing_data/accessing_data_through_REST_API.rst
@@ -103,10 +103,59 @@ substitutes for the `BasicAuthentication` username and  password.
 
     headers = {'Authorization': 'Token API-token-copied-from-User-Profile'}
     response = requests.get('http://127.0.0.1:8888/api/targets/', headers=headers)
-    targets = response.json()
+    print('status:', response.status_code)
+    print('targets:  ', response.json())
 
 Don't hard-code real credentials: read the password or token from an environment
 variable (e.g. ``os.environ['TOM_API_TOKEN']``) as in the ``curl`` example above.
 
+Obtaining your API Token programmatically
+#########################################
+
+Above, we've seen how to access your TOM's data using ``curl`` and ``Python``,
+via ``BasicAuthentication`` (username, password) and ``TokenAuthentication`` (API Token).
+
+Your API Token is available from the User Info card of your User Profile. (You may rotate
+your API Token from the User Profile update page (available from the pencil (edit) icon of
+the User Info card). Rotating your API token is analogous to, but separate from, changing
+your password).
+
+Here we show how to obtain your API Token programmatically. Django REST Framework
+provides the mechanism for this and it is available at a the ``api/token-auth`` endpoint.
+
+Using curl
+******************************************
+
+Using the same assumptions as above with respect to ``host``, ``port``, ``username``,
+and ``password``:
+
+.. code:: bash
+
+    curl --request POST http://127.0.0.1:8888/api/token-auth/ \
+         --header "Content-Type: application/json" \
+         --data '{"username": "tom_user_1", "password": "your-password"}'
+
+Things to note here:
+ - This is a ``POST`` request.
+ - The ``Content-Type`` specified in the request header lets DRF know to expect a JSON payload.
+ - The ``BasicAuthentication`` credentials are passed as the JSON payload of the request.
+
+The ouput you see will be JSON to stdout of the form ``{"token":"3bc76a8b6400182d617e9a1ce75dfa92d87412a0"}``.
+
+Using Python
+******************************************
+Here is the equivalent request made from Python code:
+
+.. code:: python
+
+    import requests
+
+    response = requests.post(
+        'http://127.0.0.1:8888/api/token-auth/',
+        json={'username': 'tom_user_1', 'password': 'your-password'},
+    )
+    print('status:', response.status_code)
+    print('json:  ', response.json())  # {"token":"3bc76a8b6400182d617e9a1ce75dfa92d87412a0"}
 
 
+Further details can be found in the `DRF Authentication API Guide <https://www.django-rest-framework.org/api-guide/authentication/>`_.

--- a/docs/managing_data/accessing_data_through_REST_API.rst
+++ b/docs/managing_data/accessing_data_through_REST_API.rst
@@ -1,0 +1,111 @@
+Accessing data through the REST API
+---------------------------------------
+
+`Django REST Framework (DRF) <https://www.django-rest-framework.org/>`_ is built into TOM Toolkit.
+This allows you to access the data in your TOM's database through a REST API.
+
+.. note::
+    If the ``DEFAULT_AUTHENTICATION_CLASSES`` key is not present in your
+    ``settings.REST_FRAMEWORK`` configuration dictionary, then you get
+    ``SessionAuthentication``, and ``BasicAuthentication`` because that's the DRF default.
+    To add ``TokenAuthentication``, your ``DEFAULT_AUTHENTICATION_CLASSES`` should look like this:
+
+    .. code:: python
+
+        REST_FRAMEWORK = {
+            'DEFAULT_AUTHENTICATION_CLASSES': [
+                'rest_framework.authentication.TokenAuthentication',
+                'rest_framework.authentication.SessionAuthentication',
+                'rest_framework.authentication.BasicAuthentication',
+            ],
+            # ... your existing REST_FRAMEWORK settings ...
+        }
+
+    - ``BasicAuthentication`` is used when you send username/password credentials in the ``AuthorizationHeader`` of an HTTP request.
+    - ``SessionAuthentication`` uses a cookie and CSRF protection to access the API from your TOM in a browser while logged in.
+    - ``TokenAuthentication`` uses your ``API Token`` available from the User Info of your User Profile of your TOM.
+
+    To see ``SessionAuthentication`` in action, while logged into your TOM, point your browser to the ``/api/`` endpoint.
+    This is the DRF API root. We'll show ``BasicAuthentication`` and ``TokenAuthentication`` in use below.
+
+
+Quick start: querying targets with curl
+#########################################
+
+The examples below query the targets endpoint on a TOM running locally at
+``http://127.0.0.1:8888`` with a user ``tom_user_1``. Adjust the host, port and
+username to match your deployment.
+
+Basic Authentication
+*************************************************
+
+.. code:: bash
+
+    curl -u tom_user_1  http://127.0.0.1:8888/api/targets/
+
+You'll be prompted for ``tom_user_1``'s password.
+You should receive a JSON blob with target data. Don't forget that trailing ``/``.
+
+This is ``BasicAuthentication``: ``curl`` sends the username and password in the
+``AuthenticationHeader`` of the HTTP request. 
+
+Token Authentication
+*************************************************
+
+Every user has a personal API token, shown as **API Token** on their
+**User Profile** page. A token suits scripts and cron jobs because it
+needs no interactive prompt. Treat it like a password.
+
+Rather than pass in a username and be prompted for a password, we'll authenticate
+by sending the token in an ``Authorization`` header:
+
+To keep the API token out of your command history and scripts, export it as an
+environment variable once and reference it in the header:
+
+.. code:: bash
+
+    export TOM_API_TOKEN="API-token-copied-from-User-Profile"
+    curl -H "Authorization: Token $TOM_API_TOKEN" http://127.0.0.1:8888/api/targets/
+
+
+Next Step: querying targets in code
+#########################################
+
+The same requests work from Python with the
+`requests <https://requests.readthedocs.io/>`_ library.
+
+Basic Authentication
+*************************************************
+
+Pass your username and password as the ``auth`` tuple:
+
+.. code:: python
+
+    import requests
+
+    response = requests.get(
+        'http://127.0.0.1:8888/api/targets/',
+        auth=('tom_user_1', 'your-password'),
+    )
+    targets = response.json()
+
+``targets`` now holds the same JSON you got back from ``curl``.
+
+Token Authentication
+*************************************************
+
+Send your API token in an ``Authorization`` header instead. No password needed:
+
+.. code:: python
+
+    import requests
+
+    headers = {'Authorization': 'Token API-token-copied-from-User-Profile'}
+    response = requests.get('http://127.0.0.1:8888/api/targets/', headers=headers)
+    targets = response.json()
+
+Don't hard-code real credentials: read the password or token from an environment
+variable (e.g. ``os.environ['TOM_API_TOKEN']``) as in the ``curl`` example above.
+
+
+

--- a/docs/managing_data/index.rst
+++ b/docs/managing_data/index.rst
@@ -11,6 +11,7 @@ Managing Data
   Continuous data sharing <continuous_sharing>
   Streaming data <stream_pub_sub>
   Single-target data service <single_target_data_service>
+  Accessing data through the REST API <accessing_data_through_REST_API>
   Visualizing data <plotting_data>
 
 The TOM's Data Models

--- a/tom_base/settings.py
+++ b/tom_base/settings.py
@@ -308,6 +308,11 @@ HINTS_ENABLED = False
 HINT_LEVEL = 20
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.TokenAuthentication',  # for API token authentication
+        'rest_framework.authentication.SessionAuthentication',  # for logged-in browsers (cookie + CSRF protection)
+        'rest_framework.authentication.BasicAuthentication',  # for username/password
+    ],
     'DEFAULT_PERMISSION_CLASSES': [
     ],
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',

--- a/tom_setup/templates/tom_setup/settings.tmpl
+++ b/tom_setup/templates/tom_setup/settings.tmpl
@@ -310,6 +310,11 @@ HINTS_ENABLED = {{ HINTS_ENABLED }}
 HINT_LEVEL = 20
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.TokenAuthentication',  # for API token authentication
+        'rest_framework.authentication.SessionAuthentication',  # for logged-in browsers (cookie + CSRF protection)
+        'rest_framework.authentication.BasicAuthentication',  # for username/password
+    ],
     'DEFAULT_PERMISSION_CLASSES': [
     ],
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',

--- a/tom_targets/tests/test_api.py
+++ b/tom_targets/tests/test_api.py
@@ -1,10 +1,12 @@
 from tom_targets.base_models import get_target_model_app_label
+import base64
 import copy
 
 from django.contrib.auth.models import User, Group
 from django.urls import reverse
 from guardian.shortcuts import assign_perm, get_objects_for_user
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
 from tom_targets.tests.factories import SiderealTargetFactory, NonSiderealTargetFactory
@@ -307,3 +309,55 @@ class TestTargetExtraViewset(APITestCase):
         response = self.client.delete(reverse('api:targetextra-detail', args=(self.extra.id,)))
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(TargetExtra.objects.filter(pk=self.extra.id).exists())
+
+
+class TestTargetAPIAuthentication(APITestCase):
+    """Exercise the three authentication schemes enabled on the DRF API by
+    ``REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']``: Token, Basic, and
+    Session. Each should authenticate the request and limit returned targets to the
+    targets the user has ``view_target`` permission on.
+    """
+
+    def setUp(self):
+        # Basic and Session auth need real credentials, so create the user with a
+        # known password that we can pass in the authroization header.
+        self.password = 'sup3r-s3cret-p4ss'
+        self.user = User.objects.create_user(username='api_user', password=self.password)
+
+        # One visible and one hidden target, so a successful auth is proven by the
+        # user seeing exactly the single target they have permission on.
+        self.visible_target = SiderealTargetFactory.create(name='visible', targetextra_set=None, aliases=None)
+        SiderealTargetFactory.create(name='hidden', targetextra_set=None, aliases=None)
+        target_app_label = get_target_model_app_label()
+        assign_perm(f'{target_app_label}.view_target', self.user, self.visible_target)
+
+        self.list_url = reverse('api:targets-list')
+
+    def assertOnlyVisibleTarget(self, response):
+        """Assert the response is a 200 listing exactly the user's one visible target."""
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()['results']
+        self.assertEqual([target['name'] for target in results], ['visible'])
+
+    def test_token_authentication(self):
+        """A valid API token authenticates the request (the scheme scripts and cron jobs use)."""
+        token, _ = Token.objects.get_or_create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+        self.assertOnlyVisibleTarget(self.client.get(self.list_url))
+
+    def test_invalid_token_is_rejected(self):
+        """An unrecognised token is rejected with 401, proving token auth is actually enforced."""
+        self.client.credentials(HTTP_AUTHORIZATION='Token not-a-real-token')
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_basic_authentication(self):
+        """HTTP Basic credentials authenticate the request (the scheme ``curl -u`` uses)."""
+        encoded = base64.b64encode(f'{self.user.username}:{self.password}'.encode()).decode()
+        self.client.credentials(HTTP_AUTHORIZATION=f'Basic {encoded}')
+        self.assertOnlyVisibleTarget(self.client.get(self.list_url))
+
+    def test_session_authentication(self):
+        """A logged-in session authenticates the request (the scheme the browsable API uses)."""
+        self.client.login(username=self.user.username, password=self.password)
+        self.assertOnlyVisibleTarget(self.client.get(self.list_url))


### PR DESCRIPTION
This adds a page of documentation for Accessing TOM data through the Django REST Framework API built into TOM Toolkit.

Additionally, it adds `TokenAuthorization` to the list of `DEFAULT_AUTHENTICATION_CLASSES` in the DRF `settings.REST_FRAMEWORK` configuration dictionary. and tests for that. This means token-auth works out-of-the-box.

Closes
 - #1491