### PR TITLE
remove unused CSS breaking aladin

### DIFF
--- a/tom_common/static/tom_common/css/main.css
+++ b/tom_common/static/tom_common/css/main.css
@@ -149,11 +149,6 @@ td, th {
     content: '\0025BC';
 }
 
-.bottom {
-  position: absolute;
-  bottom: 20%;
-}
-
 /* Create copy button class */
 .copy-button {
     opacity: 0.75; /* Make it slightly transparent */


### PR DESCRIPTION
Class usage was removed during bootstrap update, class no longer needed.