### PR TITLE
Fix server error when downloading shared data with nothing selected

### DIFF
--- a/tom_dataproducts/sharing.py
+++ b/tom_dataproducts/sharing.py
@@ -223,7 +223,8 @@ def download_data(form_data, selected_data):
     The "title" becomes the filename, and the "message" becomes a comment at the top of the file.
     :param form_data: data from the DataShareForm
     :param selected_data: ReducucedDatums selected via the checkboxes in the DataShareForm
-    :return: CSV photometry or spectroscopy table as a StreamingHttpResponse
+    :return: CSV photometry or spectroscopy table as a StreamingHttpResponse, or None when
+             selected_data matches no photometry and there is nothing to write
     """
     # TODO: selected_data can only contain photometry PKs as of now. the share-box checkboxes are
     # only rendered in photometry_datalist_for_target.html.
@@ -243,6 +244,11 @@ def download_data(form_data, selected_data):
             'unit': datum.unit,
             'source_name': datum.source_name,
         })
+    # An empty selection would build a Table with no columns at all, so sorting it by timestamp
+    # raises rather than producing an empty file. The caller reports this to the user.
+    if not data_to_save:
+        return None
+
     table = Table(data_to_save)
     if form_data.get('share_message'):
         table.meta['comments'] = [form_data['share_message']]

--- a/tom_dataproducts/tests/tests.py
+++ b/tom_dataproducts/tests/tests.py
@@ -1,5 +1,6 @@
 from tom_targets.base_models import get_target_model_app_label
 from http import HTTPStatus
+import csv
 import os
 import tempfile
 from datetime import date, time
@@ -984,3 +985,68 @@ class TestShareDataProducts(TestCase):
             follow=True
         )
         self.assertContains(response, 'No valid data shared. These data may already exist in target TOM.')
+
+    def test_download_without_selected_photometry_reports_error(self):
+        """Downloading a DataProduct reports the problem rather than raising a server error.
+
+        The share form on the DataProduct list offers 'download', but that page renders no
+        share-box checkboxes, so the selection is always empty and there is no photometry to
+        write. Reported as #1631 against a FITS DataProduct.
+        """
+        response = self.client.post(
+            reverse('dataproducts:share', kwargs={'dp_pk': self.data_product.id}),
+            {
+                'target': self.target.id,
+                'submitter': ['test_submitter'],
+                'share_destination': ['download'],
+                'share_title': ['Updated data for thingy.'],
+                'share_message': ['test_message'],
+            },
+            follow=True
+        )
+        self.assertContains(response, 'Download provides a CSV of selected photometry, and none was '
+                                      'selected. Choose photometry with the checkboxes on the target '
+                                      'page and share that instead.')
+
+    def test_download_all_photometry_without_ticking_a_box_reports_error(self):
+        """The target photometry share form reaches the same empty selection when nothing is ticked."""
+        response = self.client.post(
+            reverse('dataproducts:share_all', kwargs={'tg_pk': self.target.id}),
+            {
+                'target': self.target.id,
+                'submitter': ['test_submitter'],
+                'share_destination': ['download'],
+                'share_title': ['Updated data for thingy.'],
+                'share_message': ['test_message'],
+            },
+            follow=True
+        )
+        self.assertContains(response, 'none was selected')
+
+    def test_download_selected_photometry_returns_csv(self):
+        """Selected photometry still downloads as a CSV named for the share title."""
+        response = self.client.post(
+            reverse('dataproducts:share_all', kwargs={'tg_pk': self.target.id}),
+            {
+                'target': self.target.id,
+                'submitter': ['test_submitter'],
+                'share_destination': ['download'],
+                'share_title': ['Updated data for thingy.'],
+                'share_message': ['test_message'],
+                'share-box': [self.rd1.pk, self.rd2.pk],
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Disposition'],
+                         'attachment; filename="updated-data-for-thingy.csv"')
+        content = b''.join(response.streaming_content).decode()
+
+        # The share message is written as a leading comment, so the header is the first
+        # uncommented line. Parse rather than matching substrings: a timestamp such as
+        # 21:47:17.512345 contains a brightness-looking "17.5".
+        self.assertIn('# test_message', content)
+        rows = list(csv.DictReader(
+            line for line in content.splitlines() if not line.startswith('#')))
+        self.assertEqual(len(rows), 2)
+        self.assertEqual({row['brightness'] for row in rows}, {'18.5', '19.5'})
+        self.assertEqual({row['bandpass'] for row in rows}, {'V', 'B'})

--- a/tom_dataproducts/views.py
+++ b/tom_dataproducts/views.py
@@ -429,10 +429,15 @@ class DataShareView(FormView):
 
             # Check Destination
             if share_destination == 'download':
-                return download_data(form_data, selected_data=selected_data)
+                download_response = download_data(form_data, selected_data=selected_data)
+                if download_response is not None:
+                    return download_response
+                messages.error(request, 'Download provides a CSV of selected photometry, and none was '
+                                        'selected. Choose photometry with the checkboxes on the target '
+                                        'page and share that instead.')
             else:
                 response = share_data_with_tom(share_destination, form_data, product_id, target_id, selected_data)
-            sharing_feedback_handler(response, self.request)
+                sharing_feedback_handler(response, self.request)
         return redirect(reverse('tom_targets:detail', kwargs={'pk': request.POST.get('target')}))
 
 


### PR DESCRIPTION
Fixes #1631

Choosing "download" on the share form builds an astropy `Table` from a list of row dicts. When the selection is empty that list is empty, so the table has no columns at all, and `table.sort(['timestamp'])` raises `ValueError: {'timestamp'} is not a subset of table columns`. That surfaces as a 500, which is the traceback in the issue.

It turns out this isn't specific to FITS files, or to data products at all. Two routes reach `DataShareView`: `dataproducts:share` from the data product list, and `dataproducts:share_all` from the target photometry list. The `share-box` checkboxes that fill the selection are only rendered in `photometry_datalist_for_target.html`, so on the data product page the selection is always empty and download fails every time regardless of what the file is. The reporter's URL, `/dataproducts/data/3/share/`, is that route. The photometry page fails the same way if you submit without ticking anything.

Both cases have the same cause, so there's one guard for them. `download_data()` now returns `None` when the selection matches no photometry, and the view reports that with `messages.error` instead of raising. `sharing_feedback_handler` moved inside the `else` branch, which looks like an unrelated change but isn't: the download branch used to return unconditionally so it could never reach that call, and without the move `response` would be unbound on the new path.

There's a second half I deliberately left alone. `download_data` ignores `product_id` entirely, so "download" on a data product can't do what the button implies even once it stops erroring. Whether that option should be removed from that form (`get_sharing_destination_options(include_download=False)` already exists) or should stream the file instead felt like that was the team's call. Happy to fix if you want

### Testing

Three tests added to `TestShareDataProducts`, covering the empty selection on both routes and the normal case still downloading. Both empty-selection tests fail with the original `ValueError` when the two source files are reverted to `dev`, so they genuinely guard the bug rather than passing on their own. The CSV test asserts on parsed rows rather than raw substrings, because a timestamp like `21:47:17.512345` contains a brightness-looking `17.5`.
