### PR TITLE
fix home URL

### DIFF
--- a/tom_common/templates/tom_common/navbar_content.html
+++ b/tom_common/templates/tom_common/navbar_content.html
@@ -5,7 +5,7 @@ For customization instructions, see tom_common/base.html
 {% endcomment %}
 
 <li class="nav-item {% if request.resolver_match.url_name == 'home' %}active{% endif %}">
-    <a class="nav-link" href="/">Home <span class="sr-only">(current)</span></a>
+    <a class="nav-link" href="{% url 'home' %}">Home <span class="sr-only">(current)</span></a>
 </li>
 <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle {% if request.resolver_match.namespace == 'targets' %}active{% endif %}" data-bs-toggle="dropdown">Targets</a>


### PR DESCRIPTION
This fixes the URL of the home button in the navbar for sites (like ours) that are not hosted at the root of their domain.